### PR TITLE
group fields in post in sanity

### DIFF
--- a/sanity/schemas/documents/post.ts
+++ b/sanity/schemas/documents/post.ts
@@ -1,237 +1,259 @@
-import { defineType } from "sanity";
+import {defineType} from 'sanity'
 
 const post = defineType({
-  title: "Post",
-  name: "post",
-  type: "document",
+  title: 'Post',
+  name: 'post',
+  type: 'document',
+  groups: [
+    {
+      title: 'Forfatter',
+      name: 'author',
+    },
+    {
+      title: 'Admin',
+      name: 'admin',
+    },
+  ],
   fields: [
     {
-      title: "Type of content",
+      title: 'Type of content',
       description: "Pick what kind of content you're creating.",
-      name: "type",
-      type: "string",
-      initialValue: "article",
+      name: 'type',
+      type: 'string',
+      initialValue: 'article',
       options: {
         list: [
-          { title: "Article", value: "article" },
-          { title: "Video", value: "video" },
-          { title: "Podcast", value: "podcast" },
+          {title: 'Article', value: 'article'},
+          {title: 'Video', value: 'video'},
+          {title: 'Podcast', value: 'podcast'},
         ],
       },
+      group: 'author',
       validation: (rule) => rule.required(),
     },
     {
-      title: "Language",
-      name: "language",
-      type: "string",
+      title: 'Language',
+      name: 'language',
+      type: 'string',
       options: {
         list: [
-          { title: "English", value: "en-US" },
-          { title: "Norwegian (Bokmål)", value: "nb-NO" },
-          { title: "Norwegian (Nynorsk)", value: "nn-NO" },
+          {title: 'English', value: 'en-US'},
+          {title: 'Norwegian (Bokmål)', value: 'nb-NO'},
+          {title: 'Norwegian (Nynorsk)', value: 'nn-NO'},
         ],
       },
+      group: 'author',
       validation: (rule) => rule.required(),
     },
     {
-      title: "Embed URL",
+      title: 'Embed URL',
       description:
         "If you're uploading a video or a podcast, you need to upload your content to somebody who knows what they're doing. Upload podcasts to anchor.fm, and videos to vimeo.com. If you need access, contact Kristofer G. Selbekk.",
-      name: "embedUrl",
-      type: "url",
+      name: 'embedUrl',
+      type: 'url',
+      group: 'author',
       validation: (rule) =>
         rule.custom((url: string | undefined, context) => {
-          const postType = context.document?.type as string;
-          if (["podcast", "video"].includes(postType) && !url) {
-            return "A URL to embed is required";
+          const postType = context.document?.type as string
+          if (['podcast', 'video'].includes(postType) && !url) {
+            return 'A URL to embed is required'
           }
-          if (
-            postType === "video" &&
-            !url?.startsWith("https://player.vimeo.com")
-          ) {
-            return "Get the embed URL, not the regular URL. It should start with player.vimeo.com/video";
+          if (postType === 'video' && !url?.startsWith('https://player.vimeo.com')) {
+            return 'Get the embed URL, not the regular URL. It should start with player.vimeo.com/video'
           }
-          return true;
+          return true
         }),
-      hidden: ({ document }) => {
-        return document?.type === "article";
+      hidden: ({document}) => {
+        return document?.type === 'article'
       },
     },
     {
-      title: "Podcast length",
-      description:
-        "The length of the podcast in minutes. You can find this on Anchor",
-      name: "podcastLength",
-      type: "number",
+      title: 'Podcast length',
+      description: 'The length of the podcast in minutes. You can find this on Anchor',
+      name: 'podcastLength',
+      type: 'number',
+      group: 'author',
       validation: (rule) =>
         rule.custom((length, context) => {
-          if (context.document?._type !== "podcast") {
-            return true;
+          if (context.document?._type !== 'podcast') {
+            return true
           }
-          return length ? true : "Please specify the length of the podcast";
+          return length ? true : 'Please specify the length of the podcast'
         }),
-      hidden: ({ document }) => {
-        return document?.type !== "podcast";
+      hidden: ({document}) => {
+        return document?.type !== 'podcast'
       },
     },
     {
-      title: "Title",
-      description: "Make it snappy!",
-      name: "title",
-      type: "string",
+      title: 'Title',
+      description: 'Make it snappy!',
+      name: 'title',
+      type: 'string',
+      group: 'author',
       validation: (rule) => rule.required(),
     },
     {
-      title: "Slug",
+      title: 'Slug',
       description:
-        "The slug is used in the URL. The complete URL will be `/post/{year}/{day}/{slug}`",
-      name: "slug",
-      type: "slug",
+        'The slug is used in the URL. The complete URL will be `/post/{year}/{day}/{slug}`',
+      name: 'slug',
+      type: 'slug',
       options: {
-        source: "title",
+        source: 'title',
       },
+      group: 'author',
       validation: (rule) => rule.required(),
     },
     {
-      name: "canonicalUrl",
-      type: "url",
-      title: "Canonical URL",
+      name: 'canonicalUrl',
+      type: 'url',
+      title: 'Canonical URL',
       description:
-        "If the content has been posted elsewhere originally, please specify the original (canonical) url here.",
+        'If the content has been posted elsewhere originally, please specify the original (canonical) url here.',
+      group: 'author',
     },
     {
-      title: "Description",
+      title: 'Description',
       description:
-        "This is the excerpt, shown at the top of the page, as well as when shared on social media.",
-      name: "description",
-      type: "descriptionText",
+        'This is the excerpt, shown at the top of the page, as well as when shared on social media.',
+      name: 'description',
+      type: 'descriptionText',
+      group: 'author',
     },
     {
-      title: "Authors",
-      description: "Remember to add yourself as an author as well!",
-      name: "authors",
-      type: "array",
+      title: 'Authors',
+      description: 'Remember to add yourself as an author as well!',
+      name: 'authors',
+      type: 'array',
       of: [
         {
-          type: "reference",
-          to: [{ type: "author" }],
+          type: 'reference',
+          to: [{type: 'author'}],
         },
       ],
+      group: 'author',
     },
     {
-      title: "Cover image",
-      name: "coverImage",
-      type: "image",
+      title: 'Cover image',
+      name: 'coverImage',
+      type: 'image',
       fields: [
         {
-          title: "Image source",
-          name: "src",
-          type: "string",
+          title: 'Image source',
+          name: 'src',
+          type: 'string',
         },
         {
-          title: "Hide from post",
+          title: 'Hide from post',
           description:
-            "Check this if you only want the image to show up on the daily summary page, not in your own post",
-          name: "hideFromPost",
-          type: "boolean",
+            'Check this if you only want the image to show up on the daily summary page, not in your own post',
+          name: 'hideFromPost',
+          type: 'boolean',
         },
       ],
+      group: 'author',
     },
     {
-      title: "Available from",
-      name: "availableFrom",
+      title: 'Available from',
+      name: 'availableFrom',
       description:
         "The date the post was or will be posted. If you don't know, just let this be as is, and somebody will do this for you :)",
-      type: "date",
+      type: 'date',
       validation: (rule) => rule.required(),
       initialValue: `${new Date().getUTCFullYear()}-12-25`,
+      group: 'admin',
     },
     {
-      title: "Category",
-      name: "tags",
+      title: 'Category',
+      name: 'tags',
       description:
         "Choose a main category for your post. Or add a new one, if you can't find the perfect one",
-      type: "array",
+      type: 'array',
       of: [
         {
-          type: "reference",
-          to: [{ type: "tag" }],
+          type: 'reference',
+          to: [{type: 'tag'}],
         },
       ],
+      group: 'author',
     },
     {
-      title: "Searcahable keywords",
-      name: "keywords",
+      title: 'Searcahable keywords',
+      name: 'keywords',
       description:
         "These are keywords people might want to search for to find your article. By default we'll include the title and category.",
-      type: "array",
-      of: [{ type: "string" }],
+      type: 'array',
+      of: [{type: 'string'}],
       options: {
-        layout: "tags",
+        layout: 'tags',
       },
+      group: 'author',
     },
     {
-      title: "Content",
-      name: "content",
-      type: "portableText",
+      title: 'Content',
+      name: 'content',
+      type: 'portableText',
+      group: 'author',
       validation: (rule) => rule.required(),
     },
     {
-      title: "Related links",
-      name: "relatedLinks",
-      description: "Recommended reading or links from the post",
-      type: "array",
+      title: 'Related links',
+      name: 'relatedLinks',
+      description: 'Recommended reading or links from the post',
+      type: 'array',
       of: [
         {
-          title: "Related link",
-          name: "relatedLink",
-          type: "object",
+          title: 'Related link',
+          name: 'relatedLink',
+          type: 'object',
           fields: [
             {
-              title: "Title",
-              name: "title",
-              type: "string",
+              title: 'Title',
+              name: 'title',
+              type: 'string',
             },
             {
-              title: "Description",
-              name: "description",
-              type: "string",
+              title: 'Description',
+              name: 'description',
+              type: 'string',
             },
             {
-              title: "URL",
-              name: "url",
-              type: "url",
+              title: 'URL',
+              name: 'url',
+              type: 'url',
             },
           ],
         },
       ],
+      group: 'author',
     },
     {
-      title: "Priority",
-      name: "priority",
+      title: 'Priority',
+      name: 'priority',
       description:
-        "Defines the ordering of posts in certain lists. Higher number means higher priority",
-      type: "number",
+        'Defines the ordering of posts in certain lists. Higher number means higher priority',
+      type: 'number',
       initialValue: 0,
+      group: 'admin',
     },
   ],
   preview: {
     select: {
-      title: "title",
-      tag: "tags.0.name",
-      author: "authors.0.fullName",
-      extraAuthor: "authors.1.fullName",
-      media: "coverImage",
+      title: 'title',
+      tag: 'tags.0.name',
+      author: 'authors.0.fullName',
+      extraAuthor: 'authors.1.fullName',
+      media: 'coverImage',
     },
-    prepare({ title, tag, author, extraAuthor, media }) {
-      const authors = extraAuthor ? `${author}, ${extraAuthor}` : author;
+    prepare({title, tag, author, extraAuthor, media}) {
+      const authors = extraAuthor ? `${author}, ${extraAuthor}` : author
       return {
         title: title,
-        subtitle: `${authors} – ${tag || "No category 🤷"}`,
+        subtitle: `${authors} – ${tag || 'No category 🤷'}`,
         media: media,
-      };
+      }
     },
   },
-});
+})
 
-export default post;
+export default post


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Gruppere-felter-i-Sanity-1306bd3085418048a86fc45ee0160c7b?pvs=4)

🐛 Type oppgave: _brukerhistorie_

🥅 Mål med PRen: 
Som en redaktør
Ønsker jeg at feltene i Sanity er gruppert
Slik at jeg kan enklere finne frem til admin feltene

## Løsning

🆕 Endring: Gruppere felter: forfatter og admin

#️⃣ Punktliste av hva som er endret:

- laget to grupper: forfatter og admin
- lagt til available from og priority inn i admin
- andre felter er lagt til i forfatter

## 🧪 Testing

Sjekk om alle felter har en gruppe og at gruppene er riktige

## Bilder

<img width="958" alt="image" src="https://github.com/user-attachments/assets/fa70b10a-f64a-4dca-8357-d1caf3858fa5">

