### PR TITLE
alt av routing i forbindelse med env variabler er nå basert på enviro…

### DIFF
--- a/app/app/server/auth.server.ts
+++ b/app/app/server/auth.server.ts
@@ -3,7 +3,7 @@ import { Params } from '@remix-run/react'
 import { Authenticator } from 'remix-auth'
 import { MicrosoftStrategy } from 'remix-auth-microsoft'
 
-import { getClientId, getClientSecret, getSanityRoot, getScopes, getSessionSecret, getTenantId } from './config.server'
+import { getClientId, getClientSecret, getApplicationRoot, getScopes, getSessionSecret, getTenantId } from './config.server'
 
 import { sessionStorage } from '~/server/session.server'
 
@@ -15,7 +15,7 @@ export const authenticator = new Authenticator<UserData>(sessionStorage)
 
 const entraIdStrategy = new MicrosoftStrategy(
   {
-    redirectUri: `${getSanityRoot()}`,
+    redirectUri: `${getApplicationRoot()}/microsoft/callback`,
     clientId: getClientId(),
     clientSecret: getClientSecret(),
     scope: getScopes(),

--- a/app/app/server/config.server.ts
+++ b/app/app/server/config.server.ts
@@ -14,7 +14,7 @@ export function getScopes(): string {
   return process.env.AZURE_AD_SCOPES ?? ''
 }
 
-export function getSanityRoot(): string {
+export function getApplicationRoot(): string {
   return process.env.APPLICATION_ROOT ?? ''
 }
 

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -4,6 +4,7 @@ import {codeInput} from "@sanity/code-input";
 import {structureTool} from "sanity/structure";
 import {defineConfig, SchemaTypeDefinition} from "sanity";
 import schemas from './schemas/schema'
+import {frontendUrl} from "./src/environment";
 
 // Define the auth provider type
 interface AuthProvider {
@@ -39,7 +40,7 @@ const config = defineConfig({
       {
         name: 'bekk-login',
         title: 'Logg inn med Bekk',
-        url: 'http://localhost:5173/microsoft/auth',
+        url: `${frontendUrl}/microsoft/auth`,
         logo: 'static/logo.svg',
       } as AuthProvider,
     ],

--- a/sanity/src/environment.ts
+++ b/sanity/src/environment.ts
@@ -1,0 +1,2 @@
+
+export const frontendUrl = process.env.SANITY_STUDIO_FRONTEND_URL


### PR DESCRIPTION
…nment variabler

## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Deploye-oppdatert-Sanity-Studio-1306bd308541806d9e11cce7a40610fa?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Gjøre så sanity redirecter til frontenden som er deployet istedenfor localhost:3333

## Løsning

🆕 Endring: Lagt inn så sanity redirecter innlogging basert på en environment variabel istedenfor hardkodet streng

#️⃣ Punktliste av hva som er endret:

- se endring

## 🧪 Testing
Sjekk at redirect går til deployet frontend
