### PR TITLE
login er nå alltid bekk

### DIFF
--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -36,6 +36,7 @@ const config = defineConfig({
   },
   auth: {
     redirectOnSingle: true,
+    mode: 'replace',
     providers: [
       {
         name: 'bekk-login',


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Fjerne-andre-alternativer-for-innlogging-enn-Bekk-1356bd308541804f94e2d9e27ddbfa9e?pvs=4)

🐛 Type oppgave: brukerhistorie

🥅 Mål med PRen: Fjerne andre innloggingsmuligheter enn bekk innlogging

## Løsning

🆕 Endring: Fjernet mulighetene til å velge andre innloggingsalternativer enn bekk

#️⃣ Punktliste av hva som er endret:

- blir nå redirectet direkte til bekk innlogging

## 🧪 Testing
Sjekk at du blir redirectet rett til bekk innlogging