### PR TITLE
Set engines (node and npm) in package.json

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -61,7 +61,8 @@
         "vite-tsconfig-paths": "^4.2.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/web/package.json
+++ b/web/package.json
@@ -68,6 +68,7 @@
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
   }
 }


### PR DESCRIPTION
Dette gir en warning om man bruker en unsupported engine. Tenker det er ryddig om vi alle bruker samme, så slipper vi muligens unna alle problemene med package-lock.json-endringer.

<img width="513" alt="image" src="https://github.com/user-attachments/assets/a2d73deb-536a-4ad0-aec7-770b42a538c7">


Hot tip: Bruk `nvm` (node version manager) for å endre node-versjonen din!