### PR TITLE
Visning av lister i artikler

### DIFF
--- a/web/app/portable-text/Components.tsx
+++ b/web/app/portable-text/Components.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { PortableTextReactComponents } from '@portabletext/react'
 
 import {
   Code,
@@ -25,7 +26,7 @@ const withSpacing = (component: React.ReactNode, margin: number = 2) => {
   return <div style={{ marginTop: `${margin}rem`, marginBottom: `${margin}rem` }}>{component}</div>
 }
 
-export const components = {
+export const components: Partial<PortableTextReactComponents> = {
   types: {
     code: (props: { value: Code }) => withSpacing(<CodeBlock code={props.value} />),
     imageWithMetadata: (props: { value: ImageWithMetadata }) => withSpacing(<ImageBlock image={props.value} />),
@@ -40,14 +41,16 @@ export const components = {
     Image: (props: { value: ImageWithMetadata }) => withSpacing(<ImageBlock image={props.value} />),
     // __block: <p>FILL IN</p>,
   },
-  list: (props: { value: { listItem: 'number' | 'bullet' }; children: React.ReactNode }) => {
-    return props.value.listItem === 'number' ? (
-      <ol className={'mt-6 list-inside list-decimal'}>{props.children}</ol>
-    ) : (
-      <ul className={'mt-6 list-inside list-disc'}>{props.children}</ul>
-    )
+
+  list: {
+    bullet: ({ children }: { children?: React.ReactNode }) => (
+      <ul className="my-6 list-inside list-disc">{children}</ul>
+    ),
+    number: ({ children }: { children?: React.ReactNode }) => (
+      <ul className="my-6 list-inside list-decimal">{children}</ul>
+    ),
   },
-  listItem: (props: { children: React.ReactNode }) => <li>{props.children}</li>,
+  listItem: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
   // marks: {
   //   link: (props: any) => (
   //     <TextLink href={props.mark.href}>{props.children}</TextLink>


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Board-15686f16cc3d4c22905c805070b1d501?p=1376bd30854180d7892aeb17caa937d6&pm=s)

🐛 Feature/bug

🥅 Vise lister bedre enn vi gjør i dag, dvs. med tall/bullet points

## Løsning

🆕 Endring: Implementert typen `lists` og `listItem` i Components. 

## 🧪 Testing

Lage en liste (ordered og unordered), eller sjekke ut listene i testartikkelen. 

## Bilder

*Før:*
![image](https://github.com/user-attachments/assets/5b8d2f27-73f5-4d84-8b78-9236bbb9e026)


*Etter:*
![image](https://github.com/user-attachments/assets/8de6e970-8e13-4e38-903a-05ee79c56c83)

