### PR TITLE
Fix/categories line

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -20,16 +20,15 @@ export const Article = ({ post }: ArticleProps) => {
       <div className="col-start-1 col-end-1 row-start-2 row-end-2 meta mb-8">
         <h1 className="font-delicious mb-8">{post.title}</h1>
         {post.tags && (
-          <div className="text-body-mobile md:text-body-desktop border-b border-bekk-night pb-1 mb-8">
+          <>
             {post.tags && post.tags.map((tag) => tag.name).join(', ')}
-          </div>
+            <HLine />
+          </>
         )}
-        <div className="text-body-mobile md:text-body-desktop border-b border-bekk-night pb-1 mb-8">
-          {post.authors && `Fra ${post.authors.map((author) => author.fullName).join(', ')}`}
-        </div>
-        <div className="text-body-mobile md:text-body-desktop border-b border-bekk-night pb-1">
-          {post.availableFrom && formatDate(post.availableFrom)}
-        </div>
+        {post.authors && `Fra ${post.authors.map((author) => author.fullName).join(', ')}`}
+        <HLine />
+        {post.availableFrom && formatDate(post.availableFrom)}
+        <HLine />
       </div>
       <div className="col-start-2 col-end-2 row-start-2 row-end-2">
         {post?.description && (
@@ -38,12 +37,13 @@ export const Article = ({ post }: ArticleProps) => {
           </div>
         )}
         {post?.content && (
-          <div className="text-body-mobile md:text-body-desktop">
-            <PortableText value={post.content} components={components} />
-          </div>
+          <PortableText value={post.content} components={components} />
         )}
       </div>
     </div>
   )
 }
 
+export const HLine = () => {
+  return <div className="border-b border-bekk-night pb-1 mb-8"></div>
+}

--- a/web/app/styles/main.css
+++ b/web/app/styles/main.css
@@ -5,6 +5,7 @@
 @tailwind utilities;
 @layer base {
     body {
+        @apply text-body-mobile md:text-body-desktop;
         font-family: 'GT-America-Standard-Regular', system-ui, sans-serif;
     }
 


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Ikke-rendre-kategori-div-hvis-kategori-ikke-finnes-1376bd308541809dad58f6643498e424?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Viser ikke strek under en tekst hvis den ikke eksisterer

## Løsning

🆕 Endring: Conditional rendering på streken under "kategori"

#️⃣ Punktliste av hva som er endret:

- Viser kun streken under "kategori" hvis kategori ikke er tom
- Flyttet gjenbrukbar kode for horisontal linje til egen komponent `HLine`
- Satte default tekststørrelse på body, slik at det ikke lenger trengs å settes i div'er etc

## 🧪 Testing

- Sjekke at streken ikke kommer opp i innlegg uten kategori, f.eks /articles/digital-produktutvikling
- Sjekke at streken kommer opp i innlegg med kategori, f.eks /articles/10-om-produktledelse


## Bilder

_Ved frontendendringer legg ved bilde av før og etter._

**Før:**
![image](https://github.com/user-attachments/assets/7b4a8873-920e-4a28-8831-7a40e0973c3c)

**Etter:**
![image](https://github.com/user-attachments/assets/b6cf4d45-d88e-4c2c-a4eb-b6cbe499c47d)
