### PR TITLE
Implementert avsnitt mellom tekstbolker

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -34,11 +34,7 @@ export const Article = ({ post }: ArticleProps) => {
             <PortableText value={post.description} components={components} />
           </div>
         )}
-        {post?.content && (
-          <div className="text-body-mobile md:text-body-desktop">
-            <PortableText value={post.content} components={components} />
-          </div>
-        )}
+        {post?.content && <PortableText value={post.content} components={components} />}
       </div>
     </div>
   )

--- a/web/app/portable-text/Components.tsx
+++ b/web/app/portable-text/Components.tsx
@@ -37,17 +37,29 @@ export const components: Partial<PortableTextReactComponents> = {
     unfurledUrl: (props: { value: UnfurledUrl }) => withSpacing(<UnfurledUrlBlock unfurledUrl={props.value} />),
     iframe: (props: { value: ImageWithMetadata }) => withSpacing(<ImageBlock image={props.value} />),
     image: (props: { value: ImageWithMetadata }) => withSpacing(<ImageBlock image={props.value} />),
-    infoBlock: (props: { value: InfoBlockType }) => <InfoBlock content={props.value.content as PortableText} />,
+    infoBlock: (props: { value: InfoBlockType }) =>
+      withSpacing(<InfoBlock content={props.value.content as PortableText} />),
     Image: (props: { value: ImageWithMetadata }) => withSpacing(<ImageBlock image={props.value} />),
-    // __block: <p>FILL IN</p>,
   },
-
+  block: {
+    h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mt-4 mb-2">{children}</h1>,
+    h2: ({ children }: { children?: React.ReactNode }) => <h2 className="mt-4 mb-2">{children}</h2>,
+    h3: ({ children }: { children?: React.ReactNode }) => <h3 className="mt-4 mb-2">{children}</h3>,
+    h4: ({ children }: { children?: React.ReactNode }) => <h4 className="mt-4 mb-2">{children}</h4>,
+    normal: ({ children }: { children?: React.ReactNode }) => {
+      const arrayChildren = React.Children.toArray(children)
+      if (!arrayChildren.length || arrayChildren.join('') === '') {
+        return null
+      }
+      return <p className="mb-4">{children}</p>
+    },
+  },
   list: {
     bullet: ({ children }: { children?: React.ReactNode }) => (
-      <ul className="my-6 list-inside list-disc">{children}</ul>
+      <ul className="mb-4 list-inside list-disc">{children}</ul>
     ),
     number: ({ children }: { children?: React.ReactNode }) => (
-      <ul className="my-6 list-inside list-decimal">{children}</ul>
+      <ul className="mb-4 list-inside list-decimal">{children}</ul>
     ),
   },
   listItem: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,

--- a/web/app/portable-text/InfoBlock.tsx
+++ b/web/app/portable-text/InfoBlock.tsx
@@ -5,7 +5,7 @@ import { components } from './Components'
 
 export const InfoBlock = ({ content }: { content: SanityPortableTextType }) => {
   return (
-    <div className="my-6 rounded bg-envelope-beige px-4 py-6">
+    <div className="px-4 pt-4 pb-1 bg-envelope-beige rounded">
       <PortableText value={content} components={components} />
     </div>
   )


### PR DESCRIPTION
Fortsatt ikke helt 100% på alle blokker, men jeg tror det er godt nok for nå!

## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Board-15686f16cc3d4c22905c805070b1d501?p=1366bd30854180fda348ebe130fe74d6&pm=s)

🐛 Type oppgave: Styling

🥅 Mål med PRen: Teksten var vanskelig å lese når alt var trykka sammen

## Løsning

🆕 Endring: Begynt å parse elementer av typen "block", og sjekket om det er type _normal, h1, h2, h3 eller h4_.

En urelatert endring: Lagt til `withSpacing` på InfoBlock, og fjernet spacingen som var inne i komponenten. Bare litt rydding, mao.