### PR TITLE
Legg til pre-commit hook som linter og kjører prettier

### DIFF
--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -1,0 +1,2 @@
+cd web
+npm run lint && npm run prettier:fix

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.1.4",
+        "husky": "^9.1.6",
         "postcss": "^8.4.38",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.3",
@@ -61,7 +62,7 @@
         "vite-tsconfig-paths": "^4.2.1"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.0.0",
         "npm": ">=10.0.0"
       }
     },
@@ -11279,6 +11280,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-list/-/humanize-list-1.0.1.tgz",
       "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA=="
+    },
+    "node_modules/husky": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/i18next": {
       "version": "23.16.4",

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
     "start": "remix-serve ./build/server/index.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "prepare": "cd .. && npx husky web/.husky"
   },
   "dependencies": {
     "@opengraphninja/react": "^0.2.0",
@@ -59,6 +60,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.4",
+    "husky": "^9.1.6",
     "postcss": "^8.4.38",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.3",


### PR DESCRIPTION
## Beskrivelse

Hvis man må committe uten at koden passerer linteren, legger man til `--no-verify` i commitmeldinga. 

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Board-15686f16cc3d4c22905c805070b1d501?p=1376bd308541800e92f8c4410b6e9997&pm=s)

🐛 Type oppgave: Quality of life

🥅 Mål med PRen: Passe på at vi ikke kan sjekke inn kode som ikke passerer linter. Bør merges etter at tailwindcss-lint-PRen er merget. 

## Løsning

- Lagt til er prepare-script i package.json som gjør litt oppsett for husky. Dette kjøres ved `npm install`
- Lagt til en pre-commit hook i .husky/