### PR TITLE
show cover image

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -4,6 +4,7 @@ import { Post } from 'utils/sanity/types/sanity.types'
 
 import { PostStamp } from '~/features/article/PostStamp'
 import { components } from '~/portable-text/Components'
+import ImageBlock from '~/portable-text/ImageBlock'
 
 type ArticleProps = {
   post: Post
@@ -33,6 +34,9 @@ export const Article = ({ post }: ArticleProps) => {
           <div className="mb-10 text-leading-mobile md:text-leading-desktop">
             <PortableText value={post.description} components={components} />
           </div>
+        )}
+        {post.coverImage && !post.coverImage.hideFromPost && (
+          <ImageBlock image={{ ...post.coverImage, _type: 'imageWithMetadata' }} />
         )}
         {post?.content && <PortableText value={post.content} components={components} />}
       </div>


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Vise-cover-image-p-artikkelside-1316bd3085418047b6c8d14c0aa6bf93?pvs=4)

🐛 Type oppgave: brukerhistorie

🥅 Mål med PRen: Vise cover image på artikkelsiden

## Løsning

🆕 Endring: Gjenbruker ImageBlock komponent for å vise cover image på artikkelsiden

## 🧪 Testing

Sjekk om bilde vises og at det ser greit ut uavhengig av skjermstørrelse

## Bilder

**Før:**
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/7ae2db5c-44e4-4a05-abae-2592a7ea8b7d">

**Etter:**
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/52d10554-4866-4003-b02c-bfd2d6c2596a">

