### PR TITLE
Tydeliggjøre visning av bold tekst

### DIFF
--- a/web/app/styles/main.css
+++ b/web/app/styles/main.css
@@ -20,6 +20,10 @@
   h3 {
     @apply text-subtitle-mobile md:text-subtitle-desktop;
   }
+
+  strong {
+    font-family: 'GT-America-Standard-Medium';
+  }
 }
 
 .striped-frame {


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://youtu.be/dQw4w9WgXcQ?si=hTxgKoMFcM_-iQpm)

💄  Type oppgave: Styling

🥅 Mål med PRen: Bold tekst var veldig lite synlig i chrome. Litt bedre i firefox

## Løsning

🆕 Endring: Bruker font GT-America-Medium i stedet for GT-America-Light i alle <strong />-tags

## Bilder

**Før:**
<img width="987" alt="image" src="https://github.com/user-attachments/assets/8e8f3917-6270-46fa-8167-7a25b1c0e186">


**Etter:**
<img width="978" alt="image" src="https://github.com/user-attachments/assets/e59ab4de-8873-4aa9-b8f1-57b9f2f5a6aa">

