### PR TITLE
update meta title and description for post and day pages

### DIFF
--- a/web/app/routes/$year.$date.$slug.tsx
+++ b/web/app/routes/$year.$date.$slug.tsx
@@ -7,8 +7,9 @@ import { Post } from '../../utils/sanity/types/sanity.types'
 
 import { Article } from '~/features/article/Article'
 
-export const meta: MetaFunction = () => {
-  return [{ title: 'Post' }, { name: 'description', content: 'Welcome to Remix!' }]
+export const meta: MetaFunction = ({ data }) => {
+  const post = data as Post
+  return [{ title: post?.title || 'Innlegg' }, { name: 'description', content: post.description }]
 }
 
 export async function loader({ params }: { params: { slug: string } }) {

--- a/web/app/routes/$year.$date._index.tsx
+++ b/web/app/routes/$year.$date._index.tsx
@@ -1,4 +1,4 @@
-import { json } from '@remix-run/node'
+import { json, MetaFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 
 import { POSTS_BY_YEAR_AND_DATE } from '../../utils/sanity/queries/postQueries'
@@ -11,6 +11,19 @@ type PostsByDate = {
   posts: Post[]
   year: string
   date: string
+}
+
+export const meta: MetaFunction = ({ data }) => {
+  const postsByDate = data as PostsByDate
+  return [
+    { title: `Innlegg fra ${postsByDate.date}. desember ${postsByDate.year}` },
+    {
+      name: 'description',
+      content: `Se ${
+        postsByDate.posts.length > 1 ? `alle ${postsByDate.posts.length} innlegg` : `innholdet`
+      } fra Bekk på dag ${postsByDate.date} i julesesongen ${postsByDate.year}`,
+    },
+  ]
 }
 
 export async function loader({ params }: { params: { year: string; date: string } }) {


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Bruke-tittel-som-metadata-i-fane-1376bd3085418025a757f2d63b3ecabb?pvs=4)

🐛 Type oppgave: _brukerhistorie_

🥅 Mål med PRen: Oppdatere meta på artikkel og luke-siden

## Løsning

🆕 Endring: Lagt til dynamisk tittel og beskrivelse i meta på artikkel og luke siden

#️⃣ Punktliste av hva som er endret:

- oppdaterer tittel og beskrivelse i meta på artikkel siden (tittel og beskrivelse hentes fra innlegget)
- oppdaterer tittel og beskrivelse i meta på luke siden (tittel settes til "Innlegg fra DAG desember ÅR", og beskrivelse settes til "Se alle ANTALL innlegg fra Bekk på dag DAG i julesesongen ÅR")

## 🧪 Testing

Sjekk at tittel i tabben endrer seg fra luke til luke, og fra artikkel til artikkel