### PR TITLE
Feilmelding i stedet for kræsj ved tom luke

### DIFF
--- a/web/app/routes/$year.$date._index.tsx
+++ b/web/app/routes/$year.$date._index.tsx
@@ -17,13 +17,9 @@ export async function loader({ params }: { params: { year: string; date: string 
   const formatDate = params.year + '-' + '12' + '-' + params.date
   try {
     const { data: posts } = await loadQuery<Post[]>(POSTS_BY_YEAR_AND_DATE, { date: formatDate })
-    if (!posts || posts.length === 0) {
-      // Validate if post exists
-      throw new Response('No post found for this date', { status: 404 })
-    }
 
     return json<PostsByDate>({
-      posts,
+      posts: posts ?? [],
       year: params.year,
       date: params.date,
     })
@@ -35,10 +31,12 @@ export async function loader({ params }: { params: { year: string; date: string 
 
 export default function Index() {
   const data = useLoaderData<PostsByDate>()
+
   return (
     <div className="flex flex-col items-center gap-8 max-sm:mb-8 md:my-12 md:gap-12 md:pt-8">
       <h1 className="font-delicious text-reindeer-brown">{data.date}. desember</h1>
       <div className="flex flex-col gap-8 md:gap-12">
+        {data.posts.length === 0 && <h2>I denne luka var det helt tomt, gitt!</h2>}
         {data.posts.map((post) => (
           <Link
             className="mx-4 flex justify-center"


### PR DESCRIPTION
Smekket inn en liten "Her var det tomt, gitt" i stedet for å kræsje med 500 når listen over poster for en dag er tom. Det vil sikkert ikke skje for brukere noen gang, men for redaktørene kan en sånn melding være grei å se. Så slipper de å lure på hvorfor en luke kræsjer

<img width="721" alt="image" src="https://github.com/user-attachments/assets/c2c561cf-e058-435c-b606-54328c470d3d">
