### PR TITLE
Fiks et issue med hvordan frimerket er stylet

### DIFF
--- a/web/app/features/article/PostStamp.tsx
+++ b/web/app/features/article/PostStamp.tsx
@@ -13,7 +13,12 @@ export const PostStamp = () => {
 
 const StampSvg = () => {
   return (
-    <svg width="64 md:80" height="85.6 md:107" viewBox="0 0 160 214" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      className="w-[64px] md:w-[80px] h-[85.6px] md:h-[107px]"
+      viewBox="0 0 160 214"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <g clipPath="url(#clip0_35_1034)">
         <path
           fillRule="evenodd"


### PR DESCRIPTION
## Beskrivelse

Denne PRen fikser et issue med frimerket, der man har brukt tailwind-klasser i width og height attributtene, istedenfor å bruke det som klassenavn.
