### PR TITLE
Ikke anta at sluggen er satt enda

### DIFF
--- a/sanity/resolveProductionUrl.ts
+++ b/sanity/resolveProductionUrl.ts
@@ -1,53 +1,47 @@
-import { SanityDocumentLike, Slug } from "sanity";
+import {SanityDocumentLike, Slug} from 'sanity'
 
-const remoteUrl = "https://bekk.christmas";
-const localUrl = "http://localhost:3000";
+const remoteUrl = 'https://bekk.christmas'
+const localUrl = 'http://localhost:3000'
 
 export default function resolveProductionUrl(document: SanityDocumentLike) {
-  const isLocalhost = window.location.hostname === "localhost";
-  const baseUrl = isLocalhost ? localUrl : remoteUrl;
+  const isLocalhost = window.location.hostname === 'localhost'
+  const baseUrl = isLocalhost ? localUrl : remoteUrl
 
-  const previewUrl = new URL(baseUrl);
-  previewUrl.pathname = "/api/preview";
-  previewUrl.searchParams.append(
-    "secret",
-    process.env.SANITY_STUDIO_PREVIEW_SECRET ?? ""
-  );
-  previewUrl.searchParams.append("url", getUrlForDocument(document));
+  const previewUrl = new URL(baseUrl)
+  previewUrl.pathname = '/api/preview'
+  previewUrl.searchParams.append('secret', process.env.SANITY_STUDIO_PREVIEW_SECRET ?? '')
+  previewUrl.searchParams.append('url', getUrlForDocument(document))
 
-  return previewUrl.toString();
+  return previewUrl.toString()
 }
 
 function getUrlForDocument(doc: SanityDocumentLike) {
   switch (doc._type) {
-    case "post":
-      return getUrlForPost(doc);
-    case "page":
-      return getUrlForPage(doc);
+    case 'post':
+      return getUrlForPost(doc)
+    case 'page':
+      return getUrlForPage(doc)
     default:
-      return "";
+      return ''
   }
 }
 
-function getUrlForPost(doc: SanityDocumentLike) {
-  if (!doc.slug || !doc.availableFrom) {
-    return "/";
+function getUrlForPost(doc: SanityDocumentLike & {slug?: Slug; availableFrom?: string}) {
+  if (!doc?.slug?.current || !doc?.availableFrom) {
+    return '/'
   }
-  const slug = doc.slug as Slug;
-  const date = doc.availableFrom as string;
-  if (!slug.current) {
-    return "/";
-  }
-  const { day, year } = toDayYear(date);
-  return `/post/${year}/${day}/${slug.current}`;
+  const slug = doc.slug as Slug
+  const date = doc.availableFrom as string
+  const {day, year} = toDayYear(date)
+  return `/post/${year}/${day}/${slug.current}`
 }
 
 const getUrlForPage = (doc: SanityDocumentLike) => {
-  const slug = doc.slug as Slug;
-  return `/${slug.current}`;
-};
+  const slug = doc?.slug as Slug
+  return `/${slug?.current ?? ''}`
+}
 
 const toDayYear = (date: string) => ({
-  day: date.split("-")[2],
-  year: date.split("-")[0],
-});
+  day: date.split('-')[2],
+  year: date.split('-')[0],
+})

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -1,8 +1,8 @@
-import {visionTool} from '@sanity/vision'
-import {media} from 'sanity-plugin-media'
 import {codeInput} from '@sanity/code-input'
-import {structureTool} from 'sanity/structure'
+import {visionTool} from '@sanity/vision'
 import {createAuthStore, defineConfig, SchemaTypeDefinition} from 'sanity'
+import {media} from 'sanity-plugin-media'
+import {structureTool} from 'sanity/structure'
 import schemas from './schemas/schema'
 
 // Define your schema types explicitly
@@ -31,8 +31,12 @@ const config = defineConfig({
           },
         )
 
-        const slug = post.slug.current
-        const availableFrom = new Date(post.availableFrom)
+        if (!post) {
+          return '/'
+        }
+
+        const slug = post?.slug?.current
+        const availableFrom = new Date(post?.availableFrom ?? '')
 
         const params = new URLSearchParams()
         params.set('preview', 'true')


### PR DESCRIPTION
## Beskrivelse

Når man lager en ny artikkel, så kræsjer sanity studio. Dette skjer fordi man sjekker om en slug.current er satt, uten å sjekke om slug er definert enda eller ei.

Slang på litt random spørsmålstegn til det funka 😁 