### PR TITLE
Prevent link within link which validates DOMNesting

### DIFF
--- a/web/app/features/door/Letter.tsx
+++ b/web/app/features/door/Letter.tsx
@@ -1,5 +1,5 @@
-import { PortableText } from '@portabletext/react'
 import { readingTime } from 'utils/readTime'
+import { toPlainText } from 'utils/sanity/utils'
 
 import { Post } from '../../../utils/sanity/types/sanity.types'
 
@@ -39,7 +39,7 @@ export const Letter = ({ post, showReadTime = true }: LetterProps) => {
           <div className="flex justify-end max-sm:ml-1 sm:mb-9">
             <PostStamp />
           </div>
-          <div className="hidden sm:block">{post.description && <PortableText value={post.description} />}</div>
+          <div className="hidden sm:block">{post.description && toPlainText(post.description)}</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Fikse-s-nn-at-man-ikke-f-r-error-med-node-13e6bd30854180fa8c89da31c3fd7a66?pvs=4)

🐛 BUG 

🥅 Mål med PRen: Forhindre nøsting av linker som skaper feil i konsollen

## Løsning

🆕 Endring: Istedenfor å displaye ingressen som `PortableText`, så brukte jeg `toPlainText` istedenfor slik at linker bare blir strenger på lukesiden. 
