### PR TITLE
add link to archive

### DIFF
--- a/web/app/features/teaser/TeaserPage.tsx
+++ b/web/app/features/teaser/TeaserPage.tsx
@@ -65,6 +65,11 @@ export const TeaserPage = () => {
             <Letter post={mockPost} showReadTime={false} />
           </Link>
         </div>
+        <div className="flex justify-center mt-16">
+          <Link to={'/archive'} className="text-xl text-black hover:text-reindeer-brown ">
+            Se tidligere julekalendere
+          </Link>
+        </div>
       </div>
     </main>
   )


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Lenke-til-arkiv-1426bd30854180c0b0edc1115d9ba624?pvs=4)

🐛 Type oppgave: _brukerhistorie_

🥅 Mål med PRen: Lenke til arkiv for å kunne se tidligere julekalendere

## Løsning

🆕 Endring: Lagt til lenke på teaserpage som sender brukeren til arkiv

## 🧪 Testing

Gå på teaser siden og bruk lenken for å komme videre til arkiv. Kom gjerne med innspill på hvordan dette kan forbedres visuelt

## Bilder

**Før:**
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/e96d1512-ce46-4663-96a8-15d027f5654a">

**Etter:**
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/270ff67a-06c4-43bb-be50-2c17cf30566b">

