### PR TITLE
Ikke vis luker, dager og år før de er tilgjengelige

### DIFF
--- a/web/app/routes/$year.$date.$slug.tsx
+++ b/web/app/routes/$year.$date.$slug.tsx
@@ -1,6 +1,7 @@
-import type { HeadersFunction, MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 import { urlFor } from 'utils/sanity/sanity.server'
+import { z } from 'zod'
 
 import { POST_BY_SLUG } from '../../utils/sanity/queries/postQueries'
 import { loadQuery } from '../../utils/sanity/store'
@@ -51,8 +52,28 @@ export const headers: HeadersFunction = () => ({
   'Cache-Control': 'max-age=60, stale-while-revalidate=86400',
 })
 
-export async function loader({ params }: { params: { slug: string } }) {
-  const { data: post } = await loadQuery<Post>(POST_BY_SLUG, { slug: params.slug })
+const ParamsSchema = z.object({
+  year: z.string().min(4).max(4),
+  date: z.string().min(2).max(2),
+  slug: z.string().min(1),
+})
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const parsedParams = ParamsSchema.safeParse(params)
+  if (!parsedParams.success) {
+    throw new Response('Invalid params', { status: 400 })
+  }
+  const { year, date, slug } = parsedParams.data
+  const { data: post } = await loadQuery<Post>(POST_BY_SLUG, { slug })
+  const isPreview = new URLSearchParams(request.url).get('preview') === 'true'
+
+  const formatDate = year + '-' + '12' + '-' + date
+  const currentDate = new Date()
+
+  const targetDate = new Date(formatDate)
+  if (!isPreview && currentDate < targetDate) {
+    throw new Response('Date not yet available', { status: 425 })
+  }
 
   const imageUrl = post.coverImage ? urlFor(post.coverImage).width(1200).format('webp').url() : undefined
 

--- a/web/app/routes/$year.$date._index.tsx
+++ b/web/app/routes/$year.$date._index.tsx
@@ -1,5 +1,6 @@
-import { json, MetaFunction } from '@remix-run/node'
+import { json, LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
+import { z } from 'zod'
 
 import { POSTS_BY_YEAR_AND_DATE } from '../../utils/sanity/queries/postQueries'
 import { loadQuery } from '../../utils/sanity/store'
@@ -38,15 +39,34 @@ export const headers = () => ({
   'Cache-Control': 'max-age=60, stale-while-revalidate=86400',
 })
 
-export async function loader({ params }: { params: { year: string; date: string } }) {
-  const formatDate = params.year + '-' + '12' + '-' + params.date
+const ParamsSchema = z.object({
+  year: z.string().min(4).max(4),
+  date: z.string().min(2).max(2),
+})
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const parsedParams = ParamsSchema.safeParse(params)
+  if (!parsedParams.success) {
+    throw new Response('Invalid params', { status: 400 })
+  }
+  const { year, date } = parsedParams.data
+
+  const isPreview = new URLSearchParams(request.url).get('preview') === 'true'
+  const formatDate = year + '-' + '12' + '-' + date
+  const currentDate = new Date()
+
+  const targetDate = new Date(formatDate)
+  if (!isPreview && currentDate < targetDate) {
+    throw new Response('Date not yet available', { status: 425 })
+  }
+
   try {
     const { data: posts } = await loadQuery<Post[]>(POSTS_BY_YEAR_AND_DATE, { date: formatDate })
 
     return json<PostsByDate>({
       posts: posts ?? [],
-      year: params.year,
-      date: params.date,
+      year,
+      date,
     })
   } catch (error) {
     console.error('Error loading posts:', error)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,8 @@
         "remix-auth-microsoft": "^2.0.1",
         "sanity": "^3.62.3",
         "tailwind-merge": "^2.5.4",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@remix-run/dev": "^2.9.1",
@@ -21014,6 +21015,7 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,8 @@
     "remix-auth-microsoft": "^2.0.1",
     "sanity": "^3.62.3",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.9.1",


### PR DESCRIPTION
## Beskrivelse

Denne PRen gjør to ting:

- Legger til zod-validering av params (year, date, slug) der det gir mening. Det gir oss både typesikkerhet, runtime sikkerhet, og en fin måte og returnere en fornuftig respons til folk som skriver teite ting som /1337/69/yolo i URLen. 
- Om en artikkel ikke er tilgjengelig (og preview=true ikke er satt i URLen), så burde man returnere [425 Too Early](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425). Kanskje en litta misuse av hva den egentlig er tiltenkt, men det er jo litt moro lell.

Helt åpen for at dere ditcher denne PRen, og løser det på en annen måte, men her er et lettbeint forslag (som jeg ikke har testet overhodet).