### PR TITLE
Bruk riktig metode for å hente ut dag av måned

### DIFF
--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -42,7 +42,7 @@ const config = defineConfig({
         params.set('preview', 'true')
         params.set('dataset', dataset)
 
-        return `${process.env.SANITY_STUDIO_FRONTEND_URL}/${availableFrom.getFullYear()}/${availableFrom.getDay()}/${slug}?${params}`
+        return `${process.env.SANITY_STUDIO_FRONTEND_URL}/${availableFrom.getFullYear()}/${availableFrom.getDate()}/${slug}?${params}`
       }
 
       return prev


### PR DESCRIPTION
## Beskrivelse

Denne PRen fikser en bug der preview-URLen ikke samsvarer med det som er satt i `availableFrom`-feltet.

Grunnen er at man henter ut hvilken dag av måneden det er med `Date.prototype.getDay`. Denne funksjonen returnerer hvilken dag av uken det er, OBVIOUSLY.

Istedenfor kan man bruke `Date.prototype.getDate`, som jeg gjør her.