### PR TITLE
Fiks bug hvor spotify embeds fikk en intern scroll

### DIFF
--- a/web/app/portable-text/PodcastBlock.tsx
+++ b/web/app/portable-text/PodcastBlock.tsx
@@ -1,5 +1,13 @@
 type PodcastProps = { src: string; title: string }
 
 export default function PodcastBlock({ podcast }: { podcast: PodcastProps }) {
-  return <iframe src={podcast.src} title={podcast.title} width="100%" />
+  return (
+    <iframe
+      src={podcast.src}
+      title={podcast.title}
+      className="w-full overflow-hidden"
+      // Note: scrolling="no" er deprekert, men det finnes ingen annen måte å få riktig høyde på iframe'en på visstnok
+      scrolling="no"
+    />
+  )
 }


### PR DESCRIPTION
## Beskrivelse

Når man prøver å embedde spotify podcaster, så ser man at de scroller internt. Merkelig designet fra deres side. 

Anyways, du kan slå av scrolling i iframes, og for podcasts så vil man vel alltid slå av scrolling. Så satt `scrolling="no"` som en parameter til den iframen. Den attributten er visstnok deprekert, men det finnes ikke noen god måte å gjøre det samme på i CSS, og det funker, så hvorfor ikke.