### PR TITLE
fix: breadcrumbs and styling on luke page

### DIFF
--- a/web/app/hooks/useBreadcrumbs.ts
+++ b/web/app/hooks/useBreadcrumbs.ts
@@ -11,22 +11,23 @@ export function useBreadcrumbs(): Breadcrumb[] {
   const breadcrumbs: Breadcrumb[] = []
   let accumulatedPath = ''
 
-  if (currRoute.pathname !== '/') {
-    breadcrumbs.push({
-      href: '/',
-      title: 'Hjem',
-    })
-  }
-
   Object.keys(currRoute.params).map((key) => {
-    accumulatedPath += `/${currRoute.params[key]}`
+    accumulatedPath += `${currRoute.params[key]}`
 
     let title = ''
 
     if (key === 'year') {
-      title = '📯 Postkontoret'
+      if (currRoute.params.year && new Date(new Date().setFullYear(parseInt(currRoute.params.year))) < new Date()) {
+        title = `📯 ${currRoute.params.year}`
+      } else {
+        title = '📯 Postkontoret'
+      }
     } else if (key === 'date') {
-      title = `📬 ${currRoute.params.date}. des`
+      let date = currRoute.params.date
+      if (date && parseInt(date) < 10) {
+        date = date.replace('0', '')
+      }
+      title = `📬 ${date}. des`
     } else if (key === 'slug' && currRoute.data) {
       title = `💌 ${(currRoute.data as { title?: string })?.title ?? '💌 Innlegg'}`
     }

--- a/web/app/routes/$year.$date._index.tsx
+++ b/web/app/routes/$year.$date._index.tsx
@@ -81,11 +81,17 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
 export default function Index() {
   const data = useLoaderData<PostsByDate>()
+  let date = data.date
+  if (parseInt(data.date) < 10) {
+    date = data.date.replace('0', '')
+  }
 
   return (
     <div className="flex flex-col items-center gap-8 mb-4 lg:mb-12 md:gap-12">
-      <h1 className="self-start pl-4 font-delicious text-reindeer-brown md:self-center">{data.date}. desember</h1>
-      <div className="flex flex-col gap-8 md:gap-12">
+      <h1 className="self-start pl-4 font-delicious text-4xl md:text-5xl text-reindeer-brown sm:self-center">
+        {date}. desember
+      </h1>
+      <div className="flex flex-col max-sm:w-full gap-8 md:gap-12">
         {data.posts.length === 0 && <h2>I denne luka var det helt tomt, gitt!</h2>}
         {data.posts.map((post) => (
           <Link


### PR DESCRIPTION
## Beskrivelse

💄 STYLING / FIX

🥅 Mål med PRen: Fikse litt breadcrumbs

## Løsning

#️⃣ Punktliste av hva som er endret:

- Fikse breadcrumbs slik at 02. des blir til 2. des
- Fjerne hjem fra breadcrumbs
- Fjerne Postkontoret fra de arkiverte
- Endra litt på stylinga på overskriften på lukesiden

## Bilder
![image](https://github.com/user-attachments/assets/903dcaeb-bc33-4cbf-a292-e48137291352)
![image](https://github.com/user-attachments/assets/6e349b2f-d013-4e60-918f-2e8efbf99241)
