### PR TITLE
edit font size on image meta data

### DIFF
--- a/web/app/portable-text/ImageBlock.tsx
+++ b/web/app/portable-text/ImageBlock.tsx
@@ -42,7 +42,7 @@ export default function ImageBlock({ image }: ImageWithMetadataDisplayProps) {
         }}
       />
 
-      <figcaption className="pt-3 text-gray-500 max-sm:text-sm">
+      <figcaption className="pt-1.5 md:pt-3 text-gray-500 text-xs md:text-sm">
         {(image.caption ? image.caption : '') +
           (image.src && !image.caption?.includes(image.src) ? ` ${image.caption ? '|' : ''} Kilde: ${image.src}` : '')}
       </figcaption>


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Mindre-kildetekst-p-bilder-1436bd30854180f48fbedc11220c2144?pvs=4)

🐛 Type oppgave: styling

🥅 Mål med PRen: visuelt løft

## Løsning

#️⃣ Punktliste av hva som er endret:

- Endret størrelsen på bildetekst til xs på mobil og sm på større skjerm

## 🧪 Testing

Se over og si deg enig/uenig i størrelsen jeg har valgt 🙏 Det kan hende dere syntes den er litt vel liten, men samtidig ser det veldig mye ryddigere ut. What u think miss???

## Bilder

**Før:**
![Skjermbilde 2024-11-20 kl  07 58 10](https://github.com/user-attachments/assets/4458ec5b-7ca4-4295-b1cc-fa9843ecaf0d)
![Skjermbilde 2024-11-20 kl  07 58 40](https://github.com/user-attachments/assets/6976a89e-8405-4ce1-a866-ba0e18a7619f)

**Etter:**
![Skjermbilde 2024-11-20 kl  07 57 58](https://github.com/user-attachments/assets/6c1e969d-4d22-4876-ad19-891d32f2698f)
![Skjermbilde 2024-11-20 kl  07 59 02](https://github.com/user-attachments/assets/08ecb53f-7678-4d0a-90c0-fc945f1f120a)
