### PR TITLE
Adjust font sizes in article

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -17,29 +17,29 @@ export const Article = ({ post }: ArticleProps) => {
     <div className="px-6 sm:grid-cols-[1fr_2fr] md:grid md:grid-rows-[auto_auto] md:gap-x-12 xl:gap-x-24 md:gap-y-6 md:pl-20">
       <div className="col-span-2 col-start-1 row-start-1 row-end-1 hidden">breadcrumbs</div>
       <div className="meta col-start-1 col-end-1 row-start-2 row-end-2 mb-8">
-        <h1 className="mb-8 font-delicious text-display-mobile md:mb-12 md:text-display-desktop">{post.title}</h1>
+        <h1 className="mb-8 font-delicious md:mb-12">{post.title}</h1>
         {post.tags && (
-          <div className="mb-8 border-b border-bekk-night pb-1 text-body-mobile md:text-body-desktop">
+          <div>
             {post.tags.map((tag) => tag.name).join(', ')}
+            <Border />
           </div>
         )}
         {((post.type === 'article' && post.content) || post.type === 'podcast') && (
-          <div className="mb-8 border-b border-bekk-night pb-1 text-body-mobile md:text-body-desktop">
+          <div>
             {post.type === 'podcast' && post.podcastLength ? `${post.podcastLength} min` : readingTime(post.content)}
+            <Border />
           </div>
         )}
-        <div className="mb-8 border-b border-bekk-night pb-1 text-body-mobile md:text-body-desktop">
-          {post.authors && `Fra ${post.authors.map((author) => author.fullName).join(', ')}`}
-        </div>
-        <div className="border-b border-bekk-night pb-1 text-body-mobile md:text-body-desktop">
-          {post.availableFrom && formatDate(post.availableFrom)}
-        </div>
+        {post.authors && `Fra ${post.authors.map((author) => author.fullName).join(', ')}`}
+        <Border />
+        {post.availableFrom && formatDate(post.availableFrom)}
+        <Border />
       </div>
       <div className="col-start-2 col-end-2 row-start-2 row-end-2">
         {post?.description && (
-          <div className="mb-10 text-leading-mobile md:text-leading-desktop">
+          <h3 className="mb-10">
             <PortableText value={post.description} components={components} />
-          </div>
+          </h3>
         )}
         {post.type === 'podcast' && post.embedUrl && (
           <PodcastBlock podcast={{ src: post.embedUrl, title: post.title ?? 'podcast' }} />
@@ -61,3 +61,5 @@ export const Article = ({ post }: ArticleProps) => {
     </div>
   )
 }
+
+export const Border = () => <div className="mb-8 border-b border-bekk-night pb-1" />


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Mindre-fontst-rrelse-p-ingress-1436bd308541809ba95feedad6d817da?pvs=4)

🐛 Type oppgave: styling

## Løsning

#️⃣ Punktliste av hva som er endret:

- Fjernet unødvendig setting av font-størrelse, da den allerede er satt i main.css
- Endret ingress-font-størrelsen til å bruke subtitle istedenfor display (det som h3 er satt til som default)
- Endret tittel-font-størrelsen til å bruke headline istedenfor display (det som h1 er satt til som default)
- Laget en egen Border-komponent nederst i filen, siden den brukes lik så mange ganger
- Fjernet div'en som wrappet meta-texten for å lage border, da dette fucket med tekststørrelsen slik at den ikke automatisk ble satt til default


## Bilder

_Ved frontendendringer legg ved bilde av før og etter._

**Før:**
![Skjermbilde 2024-11-20 kl  09 38 22](https://github.com/user-attachments/assets/bb097844-63c1-422b-99d8-b13c0bc10044)

![simulator_screenshot_7788C449-4700-44FD-9AD8-B6A28276C80D](https://github.com/user-attachments/assets/2e92620b-d91e-43f5-b0b6-1bb2645ca331)

**Etter:**
![Skjermbilde 2024-11-20 kl  09 37 54](https://github.com/user-attachments/assets/8cd8ab86-7403-4cdf-83fa-00020666177d)

![simulator_screenshot_772F376C-5347-4011-A422-B2772753F8C5](https://github.com/user-attachments/assets/b4c7879c-001d-47d7-8ae8-b827b9ac308e)
