### PR TITLE
Styling/ingress

### DIFF
--- a/web/app/features/letters/Letter.tsx
+++ b/web/app/features/letters/Letter.tsx
@@ -1,6 +1,5 @@
 import { readingTime } from 'utils/readTime'
 import { toPlainText } from 'utils/sanity/utils'
-import { truncateText } from 'utils/truncateText'
 
 import { Post } from '../../../utils/sanity/types/sanity.types'
 import { PostStamp } from '../article/PostStamp'
@@ -11,7 +10,6 @@ type LetterProps = {
 }
 
 export const Letter = ({ post, showReadTime = true }: LetterProps) => {
-  const MAX_DESCRIPTION_LENGTH = 250
   return (
     <div className="striped-frame min-w-full py-6 px-6 sm:p-7">
       <div className="grid  max-w-4xl sm:grid-cols-[1fr_1px_1fr] grid-cols-[30fr_1fr]">
@@ -39,7 +37,7 @@ export const Letter = ({ post, showReadTime = true }: LetterProps) => {
           <div className="sm:mb-7 border-b border-bekk-night pb-1 mb-3" />
         </div>
         <div className="hidden sm:text-lg sm:block col-start-3 col-end-3 row-start-3 row-end-3 sm:ml-7">
-          {post.description && truncateText(toPlainText(post.description), MAX_DESCRIPTION_LENGTH)}{' '}
+          <p className="line-clamp-6"> {post.description && toPlainText(post.description)} </p>
         </div>
       </div>
     </div>

--- a/web/utils/truncateText.ts
+++ b/web/utils/truncateText.ts
@@ -1,4 +1,0 @@
-export function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text
-  return text.slice(0, maxLength) + '…'
-}


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort 1](https://www.notion.so/bekks/For-lang-ingress-p-brevet-1446bd30854180fdb7e1d9bf48667c0d?pvs=4)
💳 Lenke til [Notionkort 2](https://www.notion.so/bekks/Aligne-toppen-av-ingressen-og-toppen-av-meta-1446bd3085418062b8e0de0aab047b22?pvs=4)

🐛 Type oppgave: _Styling_

🥅 Mål med PRen: Aligner ingress med meta og setter maks lengde på ingress 

## Løsning

#️⃣ Punktliste av hva som er endret:

- satt makslengde på ingress på brevet til å være 250 characters
- endrer på grid på brevet for å aligne ingress med meta

## 🧪 Testing

Sjekk at brevene med ulik innhold ser bra ut på mobil og desktop

## Bilder

**Før:**
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/7589e6fe-3c0c-495e-934e-2cf93f35b459">

**Etter:**
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/dd6269ef-af4e-4ea2-93e5-a1b901344975">

