### PR TITLE
add link to archive

### DIFF
--- a/web/app/components/LinkToArchive.tsx
+++ b/web/app/components/LinkToArchive.tsx
@@ -1,0 +1,11 @@
+import { Link } from '@remix-run/react'
+
+export const LinkToArchive = () => {
+  return (
+    <div className="flex justify-center mt-16">
+      <Link to={'/archive'} className="text-xl text-black hover:text-reindeer-brown underline">
+        Se tidligere julekalendere
+      </Link>
+    </div>
+  )
+}

--- a/web/app/features/teaser/TeaserPage.tsx
+++ b/web/app/features/teaser/TeaserPage.tsx
@@ -4,6 +4,7 @@ import { Link } from '@remix-run/react'
 
 import { mockPost } from './mockPost'
 
+import { LinkToArchive } from '~/components/LinkToArchive'
 import { Letter } from '~/features/letters/Letter'
 
 const useClientSideOnly = () => {
@@ -65,11 +66,7 @@ export const TeaserPage = () => {
             <Letter post={mockPost} showReadTime={false} />
           </Link>
         </div>
-        <div className="flex justify-center mt-16">
-          <Link to={'/archive'} className="text-xl text-black hover:text-reindeer-brown ">
-            Se tidligere julekalendere
-          </Link>
-        </div>
+        <LinkToArchive />
       </div>
     </main>
   )

--- a/web/app/routes/$year._index.tsx
+++ b/web/app/routes/$year._index.tsx
@@ -2,6 +2,7 @@ import type { LoaderFunctionArgs, MetaFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import { z } from 'zod'
 
+import { LinkToArchive } from '~/components/LinkToArchive'
 import { Gift2SVG } from '~/features/calendar/Gift2SVG'
 import { Gift3SVG } from '~/features/calendar/Gift3SVG'
 import { GiftsSVG } from '~/features/calendar/GiftsSVG'
@@ -88,11 +89,7 @@ export default function YearRoute() {
           <Gift2SVG />
         </div>
       </div>
-      <div className="flex justify-center mt-16">
-        <Link to={'/archive'} className="text-xl text-black hover:text-reindeer-brown ">
-          Se tidligere julekalendere
-        </Link>
-      </div>
+      <LinkToArchive />
       <div className={'pt-8 flex justify-center '}>
         <p>
           Du kan også lese innlegg sorter på{' '}


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Endre-hvor-tidligere-julekalendere-linken-ligger-hen-1456bd30854180b1bdc2f7cafd3118c1?pvs=4)

🐛 Type oppgave: Brukerhistorie

🥅 Mål med PRen: at brukeren skal kunne komme frem til arkivet etter vi fjerner teaser siden

## Løsning

🆕 Endring: Lagt til lenke til arkivet til kalendersiden

## 🧪 Testing

Test om du kommer frem til arkivet fra kalendersiden

## Bilder
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/4660d98c-0304-45ba-8f06-24f5cd77c459">

