### PR TITLE
Sett riktige props på sesjonen for å få det til å funke på tvers av domener

### DIFF
--- a/web/utils/sessions.ts
+++ b/web/utils/sessions.ts
@@ -10,8 +10,8 @@ const { getSession, commitSession, destroySession } = createCookieSessionStorage
   cookie: {
     name: PREVIEW_SESSION_NAME,
     secrets: [process.env.SANITY_SESSION_SECRET],
-    sameSite: 'none',
-    secure: true,
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+    secure: process.env.NODE_ENV === 'production',
   },
 })
 


### PR DESCRIPTION
Visual editing fungerer ikke fordi __preview-cookien ikke blir godtatt av browseren. Det er mest sannsynlig fordi cookien blir satt med SameSite=lax attributten. Om man setter SameSite=None så burde det funke. 

Hvis du leser denne beskrivelsen og tenker "DETTE skjønte jeg ikke noe av", så er det helt okei – cookies er vanskelig. Skjønner det knapt selv.

Får ikke testet det uten å prodsette, så mulig vi må rulle denne tilbake etterpå.