### PR TITLE
Redirect til i år dersom man er live, eller i preview modus

### DIFF
--- a/web/app/routes/_index.tsx
+++ b/web/app/routes/_index.tsx
@@ -1,9 +1,20 @@
-import type { MetaFunction } from '@remix-run/node'
+import { type LoaderFunctionArgs, type MetaFunction, redirect } from '@remix-run/node'
+import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
 
 import { TeaserPage } from '~/features/teaser/TeaserPage'
 
 export const meta: MetaFunction = () => {
   return [{ title: 'bekk.christmas' }, { name: 'description', content: 'Welcome to Remix!' }]
+}
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const { preview } = await loadQueryOptions(request.headers)
+  const liveDate = new Date('2024-12-01')
+  const now = new Date()
+  const isLive = now > liveDate
+  if (preview || isLive) {
+    return redirect('/2024')
+  }
 }
 
 export default function Index() {


### PR DESCRIPTION
## Beskrivelse

Når man går til forsiden, burde man redirectes til i år dersom man er live (etter 1. desember 2024) eller om man er i preview modus.

Hardkodet året for nå, så det burde vi sikkert gå opp logikken for (når skal man vise nyeste kalender vs teaser.
