### PR TITLE
Legg til preview text for sammendrag av posts

### DIFF
--- a/sanity/schemas/documents/post.ts
+++ b/sanity/schemas/documents/post.ts
@@ -96,6 +96,14 @@ const post = defineType({
       group: 'author',
     },
     {
+      title: 'Preview-tekst',
+      description: 'Tekst som vises i dagsoppsummeringen og på sosiale medier',
+      name: 'previewText',
+      type: 'text',
+      group: 'author',
+      validation: (rule) => rule.max(155),
+    },
+    {
       title: 'Innhold',
       name: 'content',
       type: 'portableText',

--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -37,11 +37,11 @@ export const Article = ({ post }: ArticleProps) => {
         <Border />
       </div>
       <div className="col-start-2 col-end-2 row-start-2 row-end-2 max-md:max-w-screen-xl max-lg:max-w-lg max-xl:max-w-xl">
-        {post?.description && (
-          <h3>
+        {post?.description ? (
+          <div className="text-2xl">
             <PortableText value={post.description} components={components} />
-          </h3>
-        )}
+          </div>
+        ) : null}
         {post.type === 'podcast' && post.embedUrl && (
           <PodcastBlock podcast={{ src: post.embedUrl, title: post.title ?? 'podcast' }} />
         )}

--- a/web/app/features/letters/Letter.tsx
+++ b/web/app/features/letters/Letter.tsx
@@ -36,9 +36,15 @@ export const Letter = ({ post, showReadTime = true }: LetterProps) => {
           {post.authors && `Fra ${post.authors.map((author) => author.fullName).join(', ')}`}
           <div className="sm:mb-7 border-b border-bekk-night pb-1 mb-3" />
         </div>
-        <div className="hidden sm:text-lg sm:block col-start-3 col-end-3 row-start-3 row-end-3 sm:ml-7">
-          <p className="line-clamp-6"> {post.description && toPlainText(post.description)} </p>
-        </div>
+        {post.previewText ||
+          (post.description && (
+            <div className="hidden sm:text-lg sm:block col-start-3 col-end-3 row-start-3 row-end-3 sm:ml-7">
+              <p className="line-clamp-6">
+                {' '}
+                {post.previewText ? post.previewText : post.description ? toPlainText(post.description) : null}{' '}
+              </p>
+            </div>
+          ))}
       </div>
     </div>
   )

--- a/web/app/routes/$year.$date.$slug.tsx
+++ b/web/app/routes/$year.$date.$slug.tsx
@@ -14,12 +14,13 @@ import { Article } from '~/features/article/Article'
 export const meta: MetaFunction = ({ data }) => {
   const post = data as Post & { imageUrl?: string }
   const availableFrom = post?.availableFrom ? new Date(post.availableFrom) : undefined
+  const description = post?.previewText ?? post?.description
 
   const meta = [
     { title: post?.title || 'Innlegg' },
-    { name: 'description', content: post?.description },
+    { name: 'description', content: description },
     { property: 'og:title', content: post?.title || 'Innlegg' },
-    { property: 'og:description', content: post?.description },
+    { property: 'og:description', content: description },
     { property: 'og:type', content: 'article' },
     { property: 'og:site_name', content: 'Bekk Christmas' },
     { property: 'article:published_time', content: post?.availableFrom },
@@ -27,7 +28,7 @@ export const meta: MetaFunction = ({ data }) => {
     { property: 'article:author', content: post?.authors?.map((author) => author.fullName).join(', ') },
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:title', content: post?.title || 'Innlegg' },
-    { name: 'twitter:description', content: post?.description },
+    { name: 'twitter:description', content: description },
     { name: 'twitter:site', content: '@livetibekk' },
   ]
 

--- a/web/utils/sanity/types/sanity.types.ts
+++ b/web/utils/sanity/types/sanity.types.ts
@@ -291,6 +291,7 @@ export type Post = {
   slug?: Slug
   canonicalUrl?: string
   description?: DescriptionText
+  previewText?: string
   authors: Author[]
   coverImage?: {
     asset?: {


### PR DESCRIPTION
## Beskrivelse

Denne PRen legger til støtte for et nytt felt – `previewText` – på innlegg, som vi bruker til å vise i previews av innlegg. Den vil bli brukt i meta-tags (`description`, `og:description` etc), i tillegg til på dags-siden. Om den ikke er definert brukes `description` feltet, som før.