### PR TITLE
Husk å returnere null fra loader

### DIFF
--- a/web/app/routes/_index.tsx
+++ b/web/app/routes/_index.tsx
@@ -15,6 +15,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (preview || isLive) {
     return redirect('/2024')
   }
+  return null
 }
 
 export default function Index() {


### PR DESCRIPTION
## Beskrivelse
Remix kræsjer dersom man ikke returnerer noe fra en loader. Denne PRen fikser en bug der dette skjer av og til.