### PR TITLE
Fiks manglende tittel på innlegg i breadcrumb

### DIFF
--- a/web/app/hooks/useBreadcrumbs.ts
+++ b/web/app/hooks/useBreadcrumbs.ts
@@ -1,5 +1,7 @@
 import { useMatches } from '@remix-run/react'
 
+import { Post } from '../../utils/sanity/types/sanity.types'
+
 export type Breadcrumb = {
   href: string
   title: string
@@ -29,7 +31,8 @@ export function useBreadcrumbs(): Breadcrumb[] {
       }
       title = `📬 ${date}. des`
     } else if (key === 'slug' && currRoute.data) {
-      title = `💌 ${(currRoute.data as { title?: string })?.title ?? ' Innlegg'}`
+      const postTitle = (currRoute.data as { initial: { data: Post } }).initial.data?.title
+      title = `💌 ${postTitle ?? ' Innlegg'}`
     }
 
     breadcrumbs.push({


### PR DESCRIPTION
I breadcrumb stod det bare "💌 Innlegg", i stedet for tittel. Dette var fordi at vi aksesserte tittel fra feil objekt i useBreadcrumbs(), etter at strukturen på dataen er blitt endra. Usikker på om det er med vilje at datastrukturen her er blitt endra? Henger dette sammen med #98, `web/app/routes/$year.$date.$slug.tsx`, @selbekk?