### PR TITLE
make stamp great again

### DIFF
--- a/web/app/features/article/PostStamp.tsx
+++ b/web/app/features/article/PostStamp.tsx
@@ -10,15 +10,12 @@ type PostStampProps = {
 }
 
 export const PostStamp = ({ size, image }: PostStampProps) => {
-  if (!image) {
-    return null
-  }
-  const imageUrl = image.asset
+  const imageUrl = image?.asset
     ? urlFor(image.asset as SanityAsset)
         .height(450)
         .quality(50)
         .url()
-    : image.src
+    : image?.src
 
   return (
     <div className={`relative ${size ? size : 'h-21.4 w-16 md:h-[107px] md:w-[80px]'}`}>


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Frimerke-er-blitt-borte-1496bd30854180359b15dab35f168f70?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Frimerkt er blitt borte inne på artikkel😢

## Løsning

#️⃣ Punktliste av hva som er endret:

- Viser frimerke hvis PostStamp ikke får inn noe bilde

## Bilder

_Ved frontendendringer legg ved bilde av før og etter._

**Før:**
![image](https://github.com/user-attachments/assets/76a71f63-1dbe-4dee-b330-8e1f151b5ee8)

**Etter:**
![image](https://github.com/user-attachments/assets/a1d5c506-b05f-4547-8ba4-0beec5afc0ec)
