### PR TITLE
Legg til jump-to-content bar øverst

### DIFF
--- a/web/app/features/jump-to-content/JumpToContent.tsx
+++ b/web/app/features/jump-to-content/JumpToContent.tsx
@@ -1,0 +1,18 @@
+export const JumpToContent = () => {
+  return (
+    <a
+      href="#content"
+      onClick={(e) => {
+        e.preventDefault()
+        const content = document.getElementById('content')
+        if (content) {
+          content.focus()
+          content.scrollIntoView({ behavior: 'smooth' })
+        }
+      }}
+      className="sr-only focus:not-sr-only focus:fixed focus:top-0 focus:left-0 focus:right-0 focus:z-50 focus:p-4 focus:bg-white focus:text-black striped-frame outline-none text-center underline"
+    >
+      Hopp til hovedinnhold
+    </a>
+  )
+}

--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from 'react'
 import type { LinksFunction, LoaderFunction } from '@remix-run/node'
 import {
   json,
@@ -12,6 +11,7 @@ import {
   useRouteError,
 } from '@remix-run/react'
 import { VisualEditing } from '@sanity/visual-editing/remix'
+import { lazy, Suspense } from 'react'
 import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
 import { generateSecurityHeaders } from 'utils/security'
 
@@ -20,6 +20,7 @@ import { ArticleBackgroundSVG } from './features/article/ArticleBackgroundSVG'
 import { Header } from '~/features/navigation/Header'
 import { Page404 } from '~/routes/404'
 import styles from '~/styles/main.css?url'
+import { JumpToContent } from './features/jump-to-content/JumpToContent'
 
 export const links: LinksFunction = () => [{ rel: 'stylesheet', href: styles }]
 
@@ -65,6 +66,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <script defer data-domain="bekk.christmas" src="https://plausible.io/js/plausible.js" />
       </head>
       <body className={`m-auto min-w-[375px] max-w-screen-2xl break-words bg-envelope-beige`}>
+        <JumpToContent />
         {isInArticle && (
           <div className="fixed inset-0 -z-10">
             <ArticleBackgroundSVG />

--- a/web/app/routes/_index.tsx
+++ b/web/app/routes/_index.tsx
@@ -27,7 +27,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 export default function Index() {
   return (
-    <main id="content">
+    <main id="content" className="tabindex-[-1]">
       <TeaserPage />
     </main>
   )


### PR DESCRIPTION
## Beskrivelse

Denne PRen legger til en "jump to content" bar øverst, som første tingen man tabber til. Den er ganske stor, men det tenker jeg egentlig bare er en fordel.

<img width="1497" alt="image" src="https://github.com/user-attachments/assets/47bbdc09-0e9b-4906-af12-5fca41767008">

Det funker sånn midt på treet nå, men jeg så @annalytic hadde endret hvordan `<main />` taggen ble rendret i sitt PR, så fikser det når den er merget istedenfor.