### PR TITLE
add animation to closed door and not allow to open closed door

### DIFF
--- a/web/app/features/calendar/Door.tsx
+++ b/web/app/features/calendar/Door.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { Link } from '@remix-run/react'
+import { motion } from 'framer-motion'
 
 type DoorProps = {
   date: number
@@ -7,32 +9,63 @@ type DoorProps = {
 }
 export const Door = ({ date, year, smallScreen }: DoorProps) => {
   const [isHovered, setIsHovered] = useState(false)
+  const [isShaking, setIsShaking] = useState(false)
 
   const isOpenable = () => {
     const today = new Date()
     const doorDate = new Date(year, 11, date)
     return doorDate <= today
   }
+  const shakeAnimation = {
+    shaking: {
+      x: [-3, 3, -3, 3, 0],
+      transition: {
+        duration: 0.5,
+        ease: 'easeInOut',
+      },
+    },
+  }
+
+  const handleClick = () => {
+    if (!isOpenable()) {
+      setIsShaking(true)
+      setTimeout(() => setIsShaking(false), 500)
+    }
+  }
 
   return (
-    <div onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
-      <div className={`relative`}>
-        {isHovered && isOpenable()
-          ? smallScreen
-            ? openDoorSvg(100, 100)
-            : openDoorSvg(120, 120)
-          : smallScreen
-            ? doorSVG(100, 100)
-            : doorSVG(120, 120)}
-        <div
-          className={`absolute inset-0 flex pt-4 justify-center text-ruben-red md:text-leading-desktop font-gt-expanded ${
-            isHovered && isOpenable() ? 'hidden' : 'block'
-          }`}
-        >
-          {date}
+    <motion.div
+      onClick={handleClick}
+      animate={isShaking ? 'shaking' : ''}
+      variants={shakeAnimation}
+      initial={{ x: 0 }}
+      exit={{ x: 0 }}
+    >
+      <Link
+        to={isOpenable() ? `/post/${year}/${date.toString().padStart(2, '0')}` : '#'}
+        key={date}
+        className=" flex justify-center items-center border border-reindeer-brown"
+      >
+        <div onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
+          <div className={`relative`}>
+            {isHovered && isOpenable()
+              ? smallScreen
+                ? openDoorSvg(100, 100)
+                : openDoorSvg(120, 120)
+              : smallScreen
+                ? doorSVG(100, 100)
+                : doorSVG(120, 120)}
+            <div
+              className={`absolute inset-0 flex pt-4 justify-center text-ruben-red md:text-leading-desktop font-gt-expanded ${
+                isHovered && isOpenable() ? 'hidden' : 'block'
+              }`}
+            >
+              {date}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      </Link>
+    </motion.div>
   )
 }
 

--- a/web/app/routes/post.$year._index.tsx
+++ b/web/app/routes/post.$year._index.tsx
@@ -118,16 +118,7 @@ export default function YearRoute() {
             </div>
             {Array.from({ length: 24 }, (_, i) => {
               const date = i + 1
-              const formattedDate = (i + 1).toString().padStart(2, '0')
-              return (
-                <Link
-                  to={`/post/${data.year}/${formattedDate}`}
-                  key={date}
-                  className=" flex justify-center items-center border border-reindeer-brown"
-                >
-                  <Door year={Number(data.year)} date={date} smallScreen={smallScreen} />
-                </Link>
-              )
+              return <Door key={date} year={Number(data.year)} date={date} smallScreen={smallScreen} />
             })}
           </div>
           <div className="hidden md:flex self-end">


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Luker-som-ikke-er-pne-skal-ikke-v-re-klikkbare-14b6bd30854180f8bfdacefd0ab91054?pvs=4)

🐛 Type oppgave: brukerhistorie

🥅 Mål med PRen: Ikke la brukeren åpne dør hvis den ikke er åpnet (før dagens dato)

## Løsning

🆕 Endring: Lagt til shaking animasjon som kommer hvis man prøver å åpne en dør som ikke er åpen enda  +  brukeren blir ikke sendt videre hvis den prøver å åpne en luke som ikke er åpnet

## 🧪 Testing

Sjekk at logikken og animasjonen funker

## Bilder
I dette eksemplet er luker 1-10 åpnet, mens resten er lukket

https://github.com/user-attachments/assets/e90c8555-b221-40dc-ae62-6355e3dcc5c4


