### PR TITLE
Legg til en basic robots.txt fil

### DIFF
--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -15,7 +15,7 @@ Disallow: /api/
 Disallow: /_remix/
 
 # Add sitemap once implemented
-# Sitemap: https://bekk.christmas/sitemap.xml
+Sitemap: https://bekk.christmas/sitemap.xml
 
 # Crawl-delay to be nice to servers
 Crawl-delay: 1


### PR DESCRIPTION
## Beskrivelse

Ser vi får endel 500-feil fordi vi ikke har noen robots.txt fil. Det er egentlig et eget issue at en manglende fil gir en 500 feil, men det får vi ta en annen gang.

Denne PRen legger til robots.txt, som er en fil som forteller crawlers (som google sin etc) hvordan de skal indeksere siden.