### PR TITLE
Legg til en security.txt fil

### DIFF
--- a/web/public/.well-known/security.txt
+++ b/web/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:kristofer.selbekk@bekk.no
+Expires: 2025-12-31T22:59:00.000Z
+Preferred-Languages: no,en


### PR DESCRIPTION
## Beskrivelse

[security.txt](https://securitytxt.org/) er en foreslått standard for å gjøre det enklere for folk å si ifra om sikkerhetshull. Nå har ikke vi så veldig mye sikkerhetsgreier hos oss, men det er uansett en fin best practice å inkludere.