### PR TITLE
Bug: Fikse trebakgrunnen så den ser mindre ut

### DIFF
--- a/web/app/styles/backgrounds.css
+++ b/web/app/styles/backgrounds.css
@@ -15,19 +15,19 @@
 .bg-wooden-table {
   background-image: url('/images/bg_wood.svg');
   background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
+  background-size: 100%;
+  background-repeat: repeat;
 }
 
 .bg-wooden-table-with-cloth {
   background-image: url('../../public/images/bg_cloth.svg'), url('../../public/images/bg_wood.svg');
   background-size:
     auto 45vh,
-    cover;
+    100%;
   background-position:
     top center,
     center;
-  background-repeat: no-repeat, no-repeat;
+  background-repeat: no-repeat, repeat;
   min-height: 100vh;
 }
 


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Board-15686f16cc3d4c22905c805070b1d501?p=14c6bd308541803b80b0e0c9864ba570&pm=s)

🐛 Type oppgave: Bug

## Løsning

#️⃣ Punktliste av hva som er endret:

- Endret fra background-size til 100% og background repeat.

## Bilder


**Før:**
![Screenshot 2024-11-28 at 13 52 52](https://github.com/user-attachments/assets/06750abb-fc2b-4bae-87d8-5e434959f66e)
![Screenshot 2024-11-28 at 13 52 45](https://github.com/user-attachments/assets/1eed2a70-686d-4e2e-b088-95e5edaefde5)

**Etter:**
![Screenshot 2024-11-28 at 13 52 14](https://github.com/user-attachments/assets/ce222f11-0971-48b3-934d-819ad806424d)
![Screenshot 2024-11-28 at 13 52 21](https://github.com/user-attachments/assets/acffb09d-73fb-4865-8fdb-0e2926ff95ec)

