### PR TITLE
Legg til error-handling på relevante lenker når opengraph tryner

### DIFF
--- a/web/app/components/RelatedLink.tsx
+++ b/web/app/components/RelatedLink.tsx
@@ -4,17 +4,25 @@ import { POST_BY_SLUGResult } from 'utils/sanity/types/sanity.types'
 
 type RelatedLinkElementProps = {
   link: NonNullable<NonNullable<POST_BY_SLUGResult>['relatedLinks']>[number]
+  language: NonNullable<POST_BY_SLUGResult>['language']
 }
 
-export const RelatedLinkElement = ({ link }: RelatedLinkElementProps) => {
+export const RelatedLinkElement = ({ link, language }: RelatedLinkElementProps) => {
   const previewData = usePreviewData(link.url)
+
   if (previewData.status !== 'success') {
+    const loadingText = language === 'en-US' ? 'Loading…' : 'Laster…'
+    const errorText =
+      language === 'en-US'
+        ? 'Woops. An error has occured, and we are not able to find the link!'
+        : 'Uffda. En feil har oppstått, og vi klarer ikke å hente lenken!'
+
     return (
       <div
         key={link._key}
         className="flex items-center pl-4 mt-4 bg-light-gray rounded-xl h-full max-h-20 min-h-20 sm:max-h-28 sm:min-h-28 hover:underline hover:shadow-md transition-shadow group"
       >
-        <p>Laster…</p>
+        <p> {previewData.status === 'loading' ? loadingText : errorText} </p>
       </div>
     )
   }

--- a/web/app/features/article/RelatedLinks.tsx
+++ b/web/app/features/article/RelatedLinks.tsx
@@ -17,7 +17,7 @@ export const RelatedLinks = ({ links, language }: RelatedLinksProps) => {
           : 'Relevante lenker anbefalt av forfatteren'}
       </h3>
       {links.map((link) => (
-        <RelatedLinkElement key={link._key} link={link} />
+        <RelatedLinkElement key={link._key} link={link} language={language} />
       ))}
     </div>
   )


### PR DESCRIPTION
Kan feks skje ved 404-response på en relevant lenke. Skjer nok ikke på nyere artikler, men hvis det skjer må forfatter eller noen andre fikse det.

## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/1c622bcecc4643e8add71399d1bd3cf7?v=be83ed3fb16e4bddbd0720601a0a0d16&p=1496bd30854180c6b1cfde16c9aa55d4&pm=s)

🐛 Type oppgave: Bug 

🥅 Mål med PRen: Fikse bedre feilmelding når relevante lenker tryner

## Løsning

🆕 Endring: Sjekker `previewData.status` for om det er `loading` eller `error`, i stedet for å kun sjekke `success`. Har også lagt på språk sånn at vi kan vise engelsk når det er relevant.
