### PR TITLE
Fix teaser page, lukeside og artikkelside

### DIFF
--- a/web/app/features/teaser/TeaserPage.tsx
+++ b/web/app/features/teaser/TeaserPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import Countdown, { CountdownRendererFn } from 'react-countdown'
+import { CountdownRendererFn } from 'react-countdown'
 import { Link } from '@remix-run/react'
 
 import { PostPreview } from '../post-preview/PostPreview'
@@ -51,17 +51,11 @@ const NumberWithLabel = ({ number, label }: { number: number; label: string }) =
 )
 
 export const TeaserPage = () => {
-  const isClientSide = useClientSideOnly()
   return (
     <div className="flex flex-col items-center justify-center px-4 h-full pb-96">
       <div className="w-full items-center sm:max-w-4xl">
-        {isClientSide && (
-          <div className="text-lg text-postcard-beige sm:text-4xl md:text-5xl">
-            <Countdown date={`${new Date().getFullYear()}/12/01`} renderer={CountdownRenderer} />
-          </div>
-        )}
         <div className="mt-16">
-          <Link to={`post/${new Date() > new Date(new Date().setFullYear(2024, 12, 1)) ? '2024' : '2023'}`}>
+          <Link to="post/2024">
             <PostPreview
               title="Bekk.christmas"
               authors={['Bekk']}

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -80,7 +80,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const initial = await loadQuery<POST_BY_SLUGResult>(POST_BY_SLUG, { slug }, options)
 
   const formatDate = year + '-' + '12' + '-' + date.padStart(2, '0')
-  const currentDate = new Date()
+  const currentDate = new Date(new Date().getTime() + 1000 * 60 * 60)
   const targetDate = new Date(formatDate)
   const dateNumber = parseInt(date, 10)
 

--- a/web/app/routes/post.$year.$date._index.tsx
+++ b/web/app/routes/post.$year.$date._index.tsx
@@ -49,7 +49,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   const { preview } = await loadQueryOptions(request.headers)
   const formatDate = year + '-' + '12' + '-' + date.padStart(2, '0')
-  const currentDate = new Date()
+  const currentDate = new Date(new Date().getTime() + 1000 * 60 * 60)
 
   const dateNumber = parseInt(date, 10)
   if (!preview && (isNaN(dateNumber) || dateNumber < 1 || dateNumber > 24)) {
@@ -57,6 +57,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   const targetDate = new Date(formatDate)
+
   if (!preview && currentDate < targetDate) {
     throw new Response('Date not yet available', { status: 425 })
   }


### PR DESCRIPTION
- Endret til å bare lenke til "post/2024" uansett.
- Fjernet countdownen. Imo så det ikke så bra ut med "Nå skjer det!" som header
- Lagt på en time for å unngå feil servertid. Vi må kanskje tenke litt på hva som skjer 23:00 i kveld, da. 

