### PR TITLE
styling + title fix

### DIFF
--- a/web/app/portable-text/PodcastBlock.tsx
+++ b/web/app/portable-text/PodcastBlock.tsx
@@ -1,11 +1,13 @@
+import { cleanControlCharacters } from 'utils/controlCharacters'
+
 type PodcastProps = { src: string; title: string }
 
 export default function PodcastBlock({ podcast }: { podcast: PodcastProps }) {
   return (
     <iframe
       src={podcast.src}
-      title={podcast.title}
-      className="w-full overflow-hidden mb-8"
+      title={cleanControlCharacters(podcast.title)}
+      className="w-full overflow-hidden h-20"
       // Note: scrolling="no" er deprekert, men det finnes ingen annen måte å få riktig høyde på iframe'en på visstnok
       scrolling="no"
     />


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Fikse-whitespace-i-tittel-p-podcast-1506bd30854180bf92fbedf086c17438?pvs=4)
💳 Lenke til [Notionkort](https://www.notion.so/bekks/Fikse-for-stor-padding-p-spotify-embed-1506bd30854180a9b20be26b48bf1b7f?pvs=4)

💄  + 🐛

🥅 Mål med PRen: Fikse høyde på spotify-embed + tittel i meta


#️⃣ Punktliste av hva som er endret:

- Satte makshøyde på embed som gjorde at spacing ble mindre
- Fjernet whitespace-characters fra tittel i meta

## Bilder

**Før:**
![image](https://github.com/user-attachments/assets/2194abcb-3812-48fa-857b-03a494d0b411)

**Etter:**
![image](https://github.com/user-attachments/assets/2166d146-bae1-4ed5-b791-b2a65bea1797)
