### PR TITLE
Legg til codepen i CSPen

### DIFF
--- a/web/utils/security.ts
+++ b/web/utils/security.ts
@@ -33,6 +33,7 @@ export function generateSecurityHeaders() {
         SELF,
         '*.youtube.com',
         'codesandbox.io',
+        'codepen.io',
         'player.vimeo.com',
         'anchor.fm',
         '*.spotify.com',


### PR DESCRIPTION
## Beskrivelse

Ser at Codepen embeds ikke funker. Det er fordi vi ikke tillater dem i frame-src i CSPen.