### PR TITLE
fix error background for category and author

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -60,7 +60,7 @@ export function ErrorBoundary() {
           break
         case 404:
           if (error.data === 'Author not found') {
-            title = 'Fant ikke den forfatteren'
+            title = 'Denne forfatteren finnes ikke'
           } else if (error.data === 'No category with this name') {
             title = 'Denne kategorien finnes ikke'
           } else {

--- a/web/app/routes/forfatter.$name.tsx
+++ b/web/app/routes/forfatter.$name.tsx
@@ -70,7 +70,7 @@ export default function AuthorPage() {
   if (!author) {
     return (
       <div className="flex flex-col items-center lg:mb-12">
-        <h1 className="md:text-center mb-0">Fant ikke den forfatteren</h1>
+        <h1 className="md:text-center mb-0">Fant ikke forfatteren</h1>
       </div>
     )
   }


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Feil-bakgrunn-p-404-1506bd30854180aa9ef6e613e3e6155e?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Vise riktig bakgrunn på 404 siden på kategori og forfatter

## 🧪 Testing

Sjekk at det er riktig bakgrunn på 404 side

## Bilder

**Før:**
<img width="1643" alt="image" src="https://github.com/user-attachments/assets/26922062-ef55-4fcb-8078-ad19e7d4bc21">


**Etter:**
<img width="1672" alt="image" src="https://github.com/user-attachments/assets/92ec582b-01a6-4358-b29c-22195a50fbdc">

