### PR TITLE
add styling to day navigation

### DIFF
--- a/web/app/features/article/DayNavigation.tsx
+++ b/web/app/features/article/DayNavigation.tsx
@@ -11,7 +11,7 @@ export const DayNavigation = ({ day, year }: DayNavigationProps) => {
         <Link
           to={`/post/${year}/${day - 1}`}
           prefetch="intent"
-          className="group text-bekk-night hover:text-reindeer-brown"
+          className="group text-bekk-night hover:text-reindeer-brown styled-box-navigation px-4 py-1"
         >
           <span className="group-hover:-translate-x-1 group-hover:transition-all inline-block ">&larr;</span> {day - 1}.
           desember
@@ -21,7 +21,7 @@ export const DayNavigation = ({ day, year }: DayNavigationProps) => {
         <Link
           to={`/post/${year}/${day + 1}`}
           prefetch="intent"
-          className="group text-bekk-night hover:text-reindeer-brown"
+          className="group text-bekk-night hover:text-reindeer-brown styled-box-navigation px-4 py-1"
         >
           {day + 1}. desember{' '}
           <span className="group-hover:translate-x-1 group-hover:transition-all inline-block">&rarr;</span>

--- a/web/app/styles/main.css
+++ b/web/app/styles/main.css
@@ -153,3 +153,9 @@
   clip-path: polygon(5% 0, 95% 0, 100% 20%, 100% 80%, 95% 100%, 5% 100%, 0 80%, 0 20%);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); /* Optional: add shadow for depth */
 }
+
+.styled-box-navigation {
+  background-color: #f7f3ee; /* Beige color */
+  clip-path: polygon(5% 0, 95% 0, 100% 20%, 100% 80%, 95% 100%, 5% 100%, 0 80%, 0 20%);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); /* Optional: add shadow for depth */
+}


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Hvit-skrift-nederst-inne-p-lukesiden-1506bd3085418081933ceb9ed3dbd93c?pvs=4)

💄 STYLING

🥅 Mål med PRen: Legge til litt styling på dag-navigering

## Løsning
- La på samme tag som på kategorisiden og endra bakgrunnsfarge på pilene 

## Bilder
<img width="302" alt="image" src="https://github.com/user-attachments/assets/6d310886-615e-46ae-869b-d518b11b3134">