### PR TITLE
En post burde spesifisere hvilken serie den er en del av, ikke omvendt

### DIFF
--- a/sanity/schema.json
+++ b/sanity/schema.json
@@ -1441,109 +1441,6 @@
     }
   },
   {
-    "name": "series",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "series"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": false
-      },
-      "slug": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "slug"
-        },
-        "optional": false
-      },
-      "description": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "posts": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "object",
-            "attributes": {
-              "_ref": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string"
-                }
-              },
-              "_type": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "string",
-                  "value": "reference"
-                }
-              },
-              "_weak": {
-                "type": "objectAttribute",
-                "value": {
-                  "type": "boolean"
-                },
-                "optional": true
-              }
-            },
-            "dereferencesTo": "post",
-            "rest": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "optional": false
-      }
-    }
-  },
-  {
     "name": "tag",
     "type": "document",
     "attributes": {
@@ -1996,6 +1893,36 @@
         },
         "optional": true
       },
+      "series": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "_ref": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              }
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "reference"
+              }
+            },
+            "_weak": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "boolean"
+              },
+              "optional": true
+            }
+          },
+          "dereferencesTo": "series"
+        },
+        "optional": true
+      },
       "keywords": {
         "type": "objectAttribute",
         "value": {
@@ -2096,6 +2023,65 @@
         "type": "objectAttribute",
         "value": {
           "type": "number"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "series",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "series"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": false
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": false
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
         },
         "optional": true
       }

--- a/sanity/schemas/documents/post.ts
+++ b/sanity/schemas/documents/post.ts
@@ -167,6 +167,14 @@ const post = defineType({
       group: 'author',
     },
     {
+      title: 'Serie',
+      description: 'Hvis innlegget er en del av en serie, velg hvilken',
+      name: 'series',
+      type: 'reference',
+      to: [{type: 'series'}],
+      group: 'author',
+    },
+    {
       title: 'Søkbare nøkkelord',
       name: 'keywords',
       description: 'Nøkkelord som hjelper å søke seg fram til innlegget',

--- a/sanity/schemas/documents/series.ts
+++ b/sanity/schemas/documents/series.ts
@@ -27,12 +27,5 @@ export default defineType({
       title: 'Beskrivelse',
       type: 'text',
     }),
-    defineField({
-      name: 'posts',
-      title: 'Innlegg',
-      type: 'array',
-      of: [{type: 'reference', to: [{type: 'post'}]}],
-      validation: (rule) => rule.required().min(2),
-    }),
   ],
 })

--- a/web/utils/sanity/queries/postQueries.ts
+++ b/web/utils/sanity/queries/postQueries.ts
@@ -91,12 +91,12 @@ const POST_PROJECTION = groq`{
     name
   },
   relatedLinks,
-  "series": *[_type == "series" && references(^._id)][0] {
+  series->{
     _id, 
     title, 
     description,
     slug,
-    posts[] -> {
+    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {
       _id,
       title,
       availableFrom,

--- a/web/utils/sanity/types/sanity.types.ts
+++ b/web/utils/sanity/types/sanity.types.ts
@@ -232,24 +232,6 @@ export type SocialMediaLink = {
   url: string
 }
 
-export type Series = {
-  _id: string
-  _type: 'series'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title: string
-  slug: Slug
-  description?: string
-  posts: Array<{
-    _ref: string
-    _type: 'reference'
-    _weak?: boolean
-    _key: string
-    [internalGroqTypeReferenceTo]?: 'post'
-  }>
-}
-
 export type Tag = {
   _id: string
   _type: 'tag'
@@ -321,6 +303,12 @@ export type Post = {
     _key: string
     [internalGroqTypeReferenceTo]?: 'tag'
   }>
+  series?: {
+    _ref: string
+    _type: 'reference'
+    _weak?: boolean
+    [internalGroqTypeReferenceTo]?: 'series'
+  }
   keywords?: Array<string>
   relatedLinks?: Array<{
     title?: string
@@ -333,6 +321,17 @@ export type Post = {
   language: 'en-US' | 'nb-NO' | 'nn-NO'
   availableFrom: string
   priority?: number
+}
+
+export type Series = {
+  _id: string
+  _type: 'series'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title: string
+  slug: Slug
+  description?: string
 }
 
 export type SanityImageCrop = {
@@ -433,10 +432,10 @@ export type AllSanitySchemaTypes =
   | InfoBlock
   | Iframe
   | SocialMediaLink
-  | Series
   | Tag
   | Author
   | Post
+  | Series
   | SanityImageCrop
   | SanityImageHotspot
   | SanityImageAsset
@@ -516,6 +515,12 @@ export type ALL_POSTSResult = Array<{
     _key: string
     [internalGroqTypeReferenceTo]?: 'tag'
   }>
+  series?: {
+    _ref: string
+    _type: 'reference'
+    _weak?: boolean
+    [internalGroqTypeReferenceTo]?: 'series'
+  }
   keywords?: Array<string>
   relatedLinks?: Array<{
     title?: string
@@ -530,7 +535,7 @@ export type ALL_POSTSResult = Array<{
   priority?: number
 }>
 // Variable: POST_PROJECTION
-// Query: {     _id,  _type,  _createdAt,  _updatedAt,  _rev,  type,  language,  embedUrl,  podcastLength,  title,  slug,  canonicalUrl,  description,  previewText,  availableFrom,  keywords,  "wordCount": length(string::split(pt::text(content), ' ')),  content[] {    ...,    _type == 'imageWithMetadata' => {      ...,      asset->{        _id,        url,        metadata {          dimensions {            aspectRatio,            width,            height          }        }      }    }  },  priority,    authors[]->{    _id,    _type,    _createdAt,    _updatedAt,    _rev,    fullName,    slug,    companyName,    profilePicture,    socialMediaLinks  },    coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  tags[]->{    _id,    slug,    name  },  relatedLinks,  "series": *[_type == "series" && references(^._id)][0] {    _id,     title,     description,    slug,    posts[] -> {      _id,      title,      availableFrom,      slug    }  }}
+// Query: {  _id,  _type,  _createdAt,  _updatedAt,  _rev,  type,  language,  embedUrl,  podcastLength,  title,  slug,  canonicalUrl,  description,  previewText,  availableFrom,  keywords,  "wordCount": length(string::split(pt::text(content), ' ')),  content[] {    ...,    _type == 'imageWithMetadata' => {      ...,      asset->{        _id,        url,        metadata {          dimensions {            aspectRatio,            width,            height          }        }      }    }  },  priority,    authors[]->{    _id,    _type,    _createdAt,    _updatedAt,    _rev,    fullName,    slug,    companyName,    profilePicture,    socialMediaLinks  },    coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  tags[]->{    _id,    slug,    name  },  relatedLinks,  series->{    _id,     title,     description,    slug,    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {      _id,      title,      availableFrom,      slug    }  }}
 export type POST_PROJECTIONResult = {
   _id: never
   _type: never
@@ -555,21 +560,10 @@ export type POST_PROJECTIONResult = {
   coverImage: never
   tags: never
   relatedLinks: never
-  series: {
-    _id: string
-    title: string
-    description: string | null
-    slug: Slug
-    posts: Array<{
-      _id: string
-      title: string
-      availableFrom: string
-      slug: Slug
-    }>
-  } | null
+  series: never
 }
 // Variable: POST_BY_SLUG
-// Query: *[_type == "post" && slug.current == $slug][0]{     _id,  _type,  _createdAt,  _updatedAt,  _rev,  type,  language,  embedUrl,  podcastLength,  title,  slug,  canonicalUrl,  description,  previewText,  availableFrom,  keywords,  "wordCount": length(string::split(pt::text(content), ' ')),  content[] {    ...,    _type == 'imageWithMetadata' => {      ...,      asset->{        _id,        url,        metadata {          dimensions {            aspectRatio,            width,            height          }        }      }    }  },  priority,    authors[]->{    _id,    _type,    _createdAt,    _updatedAt,    _rev,    fullName,    slug,    companyName,    profilePicture,    socialMediaLinks  },    coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  tags[]->{    _id,    slug,    name  },  relatedLinks,  "series": *[_type == "series" && references(^._id)][0] {    _id,     title,     description,    slug,    posts[] -> {      _id,      title,      availableFrom,      slug    }  }}
+// Query: *[_type == "post" && slug.current == $slug][0]{  _id,  _type,  _createdAt,  _updatedAt,  _rev,  type,  language,  embedUrl,  podcastLength,  title,  slug,  canonicalUrl,  description,  previewText,  availableFrom,  keywords,  "wordCount": length(string::split(pt::text(content), ' ')),  content[] {    ...,    _type == 'imageWithMetadata' => {      ...,      asset->{        _id,        url,        metadata {          dimensions {            aspectRatio,            width,            height          }        }      }    }  },  priority,    authors[]->{    _id,    _type,    _createdAt,    _updatedAt,    _rev,    fullName,    slug,    companyName,    profilePicture,    socialMediaLinks  },    coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  tags[]->{    _id,    slug,    name  },  relatedLinks,  series->{    _id,     title,     description,    slug,    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {      _id,      title,      availableFrom,      slug    }  }}
 export type POST_BY_SLUGResult = {
   _id: string
   _type: 'post'
@@ -768,7 +762,7 @@ export type ARTICLE_CONTENT_BY_IDResult = {
   preferredVoice: 'none' | 'nova' | 'onyx' | 'shimmer' | null
 } | null
 // Variable: POSTS_BY_YEAR_AND_DATE
-// Query: *[_type == "post" && availableFrom == $date] {  _id,  title,  slug,  coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  availableFrom,  "tags": tags[]->.name,  "authors": authors[]->.fullName,  "summary": coalesce(previewText, pt::text(description)),  "wordCount": length(string::split(pt::text(content), ' ')),  podcastLength,}
+// Query: *[_type == "post" && availableFrom == $date] | order(priority desc) {  _id,  title,  slug,  coverImage {  _type,  asset->{    _id,    _type,    url,    metadata {      dimensions {        aspectRatio,        width,        height      }    }  },  hotspot,  crop,  src,  alt,  hideFromPost},  availableFrom,  "tags": tags[]->.name,  "authors": authors[]->.fullName,  "summary": coalesce(previewText, pt::text(description)),  "wordCount": length(string::split(pt::text(content), ' ')),  podcastLength,}
 export type POSTS_BY_YEAR_AND_DATEResult = Array<{
   _id: string
   title: string
@@ -930,10 +924,10 @@ declare module '@sanity/client' {
     '{\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n}': COVER_IMAGE_WITH_METADATA_PROJECTIONResult
     '{\n  _id,\n  title,\n  slug,\n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n  availableFrom,\n  "tags": tags[]->.name,\n  "authors": authors[]->.fullName,\n  "summary": coalesce(previewText, pt::text(description)),\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  podcastLength,\n}': POST_PREVIEW_PROJECTIONResult
     '*[_type == "post"]': ALL_POSTSResult
-    '{\n     _id,\n  _type,\n  _createdAt,\n  _updatedAt,\n  _rev,\n  type,\n  language,\n  embedUrl,\n  podcastLength,\n  title,\n  slug,\n  canonicalUrl,\n  description,\n  previewText,\n  availableFrom,\n  keywords,\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  content[] {\n    ...,\n    _type == \'imageWithMetadata\' => {\n      ...,\n      asset->{\n        _id,\n        url,\n        metadata {\n          dimensions {\n            aspectRatio,\n            width,\n            height\n          }\n        }\n      }\n    }\n  },\n  priority,\n  \n  authors[]->{\n    _id,\n    _type,\n    _createdAt,\n    _updatedAt,\n    _rev,\n    fullName,\n    slug,\n    companyName,\n    profilePicture,\n    socialMediaLinks\n  },\n  \n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n\n  tags[]->{\n    _id,\n    slug,\n    name\n  },\n  relatedLinks,\n  "series": *[_type == "series" && references(^._id)][0] {\n    _id, \n    title, \n    description,\n    slug,\n    posts[] -> {\n      _id,\n      title,\n      availableFrom,\n      slug\n    }\n  }\n}': POST_PROJECTIONResult
-    '*[_type == "post" && slug.current == $slug][0]{\n     _id,\n  _type,\n  _createdAt,\n  _updatedAt,\n  _rev,\n  type,\n  language,\n  embedUrl,\n  podcastLength,\n  title,\n  slug,\n  canonicalUrl,\n  description,\n  previewText,\n  availableFrom,\n  keywords,\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  content[] {\n    ...,\n    _type == \'imageWithMetadata\' => {\n      ...,\n      asset->{\n        _id,\n        url,\n        metadata {\n          dimensions {\n            aspectRatio,\n            width,\n            height\n          }\n        }\n      }\n    }\n  },\n  priority,\n  \n  authors[]->{\n    _id,\n    _type,\n    _createdAt,\n    _updatedAt,\n    _rev,\n    fullName,\n    slug,\n    companyName,\n    profilePicture,\n    socialMediaLinks\n  },\n  \n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n\n  tags[]->{\n    _id,\n    slug,\n    name\n  },\n  relatedLinks,\n  "series": *[_type == "series" && references(^._id)][0] {\n    _id, \n    title, \n    description,\n    slug,\n    posts[] -> {\n      _id,\n      title,\n      availableFrom,\n      slug\n    }\n  }\n}': POST_BY_SLUGResult
+    '{\n  _id,\n  _type,\n  _createdAt,\n  _updatedAt,\n  _rev,\n  type,\n  language,\n  embedUrl,\n  podcastLength,\n  title,\n  slug,\n  canonicalUrl,\n  description,\n  previewText,\n  availableFrom,\n  keywords,\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  content[] {\n    ...,\n    _type == \'imageWithMetadata\' => {\n      ...,\n      asset->{\n        _id,\n        url,\n        metadata {\n          dimensions {\n            aspectRatio,\n            width,\n            height\n          }\n        }\n      }\n    }\n  },\n  priority,\n  \n  authors[]->{\n    _id,\n    _type,\n    _createdAt,\n    _updatedAt,\n    _rev,\n    fullName,\n    slug,\n    companyName,\n    profilePicture,\n    socialMediaLinks\n  },\n  \n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n\n  tags[]->{\n    _id,\n    slug,\n    name\n  },\n  relatedLinks,\n  series->{\n    _id, \n    title, \n    description,\n    slug,\n    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {\n      _id,\n      title,\n      availableFrom,\n      slug\n    }\n  }\n}': POST_PROJECTIONResult
+    '*[_type == "post" && slug.current == $slug][0]{\n  _id,\n  _type,\n  _createdAt,\n  _updatedAt,\n  _rev,\n  type,\n  language,\n  embedUrl,\n  podcastLength,\n  title,\n  slug,\n  canonicalUrl,\n  description,\n  previewText,\n  availableFrom,\n  keywords,\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  content[] {\n    ...,\n    _type == \'imageWithMetadata\' => {\n      ...,\n      asset->{\n        _id,\n        url,\n        metadata {\n          dimensions {\n            aspectRatio,\n            width,\n            height\n          }\n        }\n      }\n    }\n  },\n  priority,\n  \n  authors[]->{\n    _id,\n    _type,\n    _createdAt,\n    _updatedAt,\n    _rev,\n    fullName,\n    slug,\n    companyName,\n    profilePicture,\n    socialMediaLinks\n  },\n  \n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n\n  tags[]->{\n    _id,\n    slug,\n    name\n  },\n  relatedLinks,\n  series->{\n    _id, \n    title, \n    description,\n    slug,\n    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {\n      _id,\n      title,\n      availableFrom,\n      slug\n    }\n  }\n}': POST_BY_SLUGResult
     '*[_type == "post" && type == "article" && _id == $id][0] { \n  title, \n  "description": pt::text(description), \n  "content": pt::text(content), \n  "mainAuthor": authors[0]->fullName,\n  "preferredVoice": authors[0]->preferredVoice\n  }': ARTICLE_CONTENT_BY_IDResult
-    '*[_type == "post" && availableFrom == $date] {\n  _id,\n  title,\n  slug,\n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n  availableFrom,\n  "tags": tags[]->.name,\n  "authors": authors[]->.fullName,\n  "summary": coalesce(previewText, pt::text(description)),\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  podcastLength,\n}': POSTS_BY_YEAR_AND_DATEResult
+    '*[_type == "post" && availableFrom == $date] | order(priority desc) {\n  _id,\n  title,\n  slug,\n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n  availableFrom,\n  "tags": tags[]->.name,\n  "authors": authors[]->.fullName,\n  "summary": coalesce(previewText, pt::text(description)),\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  podcastLength,\n}': POSTS_BY_YEAR_AND_DATEResult
     '*[_type == "tag"] | order(name asc)': ALL_CATEGORIESResult
     '{\n  "posts": *[\n    _type == "post" && \n    $t in tags[]->.slug &&\n    availableFrom < now()\n  ][$start...$end] | order(availableFrom desc) {\n  _id,\n  title,\n  slug,\n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n  availableFrom,\n  "tags": tags[]->.name,\n  "authors": authors[]->.fullName,\n  "summary": coalesce(previewText, pt::text(description)),\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  podcastLength,\n},\n  "totalCount": count(*[\n    _type == "post" && \n    $t in tags[]->.slug &&\n    availableFrom < now()\n  ]),\n  "tag": *[_type == "tag" && slug == $t][0] {\n    name,\n    slug\n  }\n}': TAG_WITH_POSTS_QUERYResult
     '{\n  "posts": *[\n    _type == "post" && \n    $slug in authors[]->slug.current && \n    availableFrom < now()\n  ][$start...$end] | order(availableFrom desc) {\n  _id,\n  title,\n  slug,\n  coverImage {\n  _type,\n  asset->{\n    _id,\n    _type,\n    url,\n    metadata {\n      dimensions {\n        aspectRatio,\n        width,\n        height\n      }\n    }\n  },\n  hotspot,\n  crop,\n  src,\n  alt,\n  hideFromPost\n},\n  availableFrom,\n  "tags": tags[]->.name,\n  "authors": authors[]->.fullName,\n  "summary": coalesce(previewText, pt::text(description)),\n  "wordCount": length(string::split(pt::text(content), \' \')),\n  podcastLength,\n},\n  "totalCount": count(*[\n    _type == "post" && \n    $slug in authors[]->slug.current && \n    availableFrom < now()\n  ]),\n  "author": *[_type == "author" && slug.current == $slug][0] {\n    fullName,\n    slug\n  }\n}': AUTHOR_WITH_POSTS_QUERYResult


### PR DESCRIPTION
## Beskrivelse

Denne PRen gjør slik at man spesifiserer hvilken (om noen) serie en post er en del av, istedenfor at serien spesifiserer hvilke poster som er med i serien.

Den eneste fleksibiliteten man går glipp av her, er at man ikke kan definere rekkefølgen i en serie. Men en serie er jo basically alltid kronologisk (man legger først ut del 1 og så del 2 osv) (med unntak av Star Wars, men la oss se bort i fra den fadesen) – så vi kan jo bare sortere på publiseringsdato.