### PR TITLE
Revert "Hotfix: Slå av preview så siden funker (#217)"

### DIFF
--- a/web/utils/sanity/loadQueryOptions.server.ts
+++ b/web/utils/sanity/loadQueryOptions.server.ts
@@ -16,10 +16,10 @@ export async function loadQueryOptions(
   }
 
   return {
-    preview: false,
+    preview,
     options: {
-      perspective: 'published', // preview ? 'previewDrafts' : 'published',
-      //stega: preview ? { enabled: true, studioUrl: process.env.SANITY_STUDIO_URL } : undefined,
+      perspective: preview ? 'previewDrafts' : 'published',
+      stega: preview ? { enabled: true, studioUrl: process.env.SANITY_STUDIO_URL } : undefined,
     },
   }
 }

--- a/web/utils/sanity/store.ts
+++ b/web/utils/sanity/store.ts
@@ -10,11 +10,11 @@ if (!token) {
 
 const clientWithToken = writeClient.withConfig({
   token,
-  perspective: 'published', //'previewDrafts',
-  //stega: {
-  //  enabled: true,
-  //  studioUrl: process.env.SANITY_STUDIO_URL,
-  //},
+  perspective: 'previewDrafts',
+  stega: {
+    enabled: true,
+    studioUrl: process.env.SANITY_STUDIO_URL,
+  },
 })
 
 queryStore.setServerClient(clientWithToken)


### PR DESCRIPTION
# Beskrivelse

Denne PRen reverter forrige PR, som slo av preview midlertidig på grunn av en prod-feil hos Sanity.