### PR TITLE
Bug: Spotify embed not enough height on different screens

### DIFF
--- a/web/app/portable-text/PodcastBlock.tsx
+++ b/web/app/portable-text/PodcastBlock.tsx
@@ -7,7 +7,7 @@ export default function PodcastBlock({ podcast }: { podcast: PodcastProps }) {
     <iframe
       src={podcast.src}
       title={cleanControlCharacters(podcast.title)}
-      className="w-full overflow-hidden h-20"
+      className="w-full overflow-hidden h-28 sm:h-28 2sm:h-44 md:h-28 lg:h-28 2xl:h-40 lg:mb-4"
       // Note: scrolling="no" er deprekert, men det finnes ingen annen måte å få riktig høyde på iframe'en på visstnok
       scrolling="no"
     />

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -49,6 +49,7 @@ export default {
       },
       screens: {
         sm: '640px',
+        '2sm': '832px', // for spotify embed
         md: '900px',
         lg: '1024px',
         '2lg': '1130px',


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Spotify-embed-kuttes-av-1516bd30854180a69052c622628a698d?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: vise hele embeden til spotify:)

## Løsning

🆕 Endring: Satt riktig høyde

#️⃣ Punktliste av hva som er endret:

- Lag til riktig høyde og satt litt margin på
- Måtte også legge til et breakpoint til i tailwind-config, fordi den embedden viser ingress-tekst i embedden basert på høyden til embedden.  
  - Viser ingress når den får høyde 161px, 
  - Problemet dukker opp når skjermstørrelsen er mellom sm/640px og md/900px, fordi da følger høyden det vi har satt på  sm-skjermstørrelse, men siden embedden legger til ingresstekst, blir høyden på embedden større og den høyden vi har satt på sm-skjerm vil da være for liten
  -  Dette skjer spesifikt på 832px

830px:
![image](https://github.com/user-attachments/assets/4f89d71a-1799-40da-82bb-50ba89fe309e)

832px:
![image](https://github.com/user-attachments/assets/b1e69653-656c-4481-99ef-a3b606e348c9)

## 🧪 Testing

Sjekke at det ser fint ut på ulike skjermstørrelser, f.eks /post/2020/15/hva-kommer-etter-saas

## Bilder

**Før:**
![image](https://github.com/user-attachments/assets/fa1be79c-a23c-4c6a-9321-0d84bff1ff53)
**Etter:**
![image](https://github.com/user-attachments/assets/1a3674c7-a5e3-4adc-8e9b-08e18926dcc3)

