### PR TITLE
Workaround for bug i react-syntax-highlighter

### DIFF
--- a/web/app/portable-text/CodeBlock.tsx
+++ b/web/app/portable-text/CodeBlock.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 
 import { Code } from '../../utils/sanity/types/sanity.types'
@@ -6,14 +7,24 @@ interface CodeBlockProps {
   code: Code
 }
 export const CodeBlock = ({ code }: CodeBlockProps) => {
-  if (!code?.code) {
+  // Denne 'unødvendige' state-variabelen er en workaround for å unngå dette: https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/538
+  const [codeState, setCodeState] = useState<string | undefined>()
+
+  useEffect(() => {
+    if (code.code) {
+      setCodeState(code.code)
+    }
+  }, [code.code])
+
+  if (!codeState) {
     return null
   }
+
   return (
     <div className="codeBlockColorOverride text-sm max-w-[800px] overflow-hidden rounded-md">
       <div className="overflow-x-auto bg-gray-50">
         <SyntaxHighlighter customStyle={{ backgroundColor: 'transparent' }} language={code.language ?? 'text'}>
-          {code.code}
+          {codeState}
         </SyntaxHighlighter>
       </div>
     </div>


### PR DESCRIPTION
Pakken vi bruker for å highlighte kodeblokker, react-syntax-highlighter, har en bug som gjør at vi noen ganger får [Object object] i stedet for kodesnutten i første render. Buggen er rapportert i flere issues, blant annet https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/538, og ser ikke ut til å fikses med det første. I mangel på alternative highlightere som funker like bra som denne, prøver vi oss med en workaround som er foreslått i nevnte issue. Andre har også nevnt at det å tvinge en ekstra render etter initial render fikser problemet, så jeg har trua 🤞

## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Bug-i-kodeeditor-Object-object-14c6bd30854180e88278d40c2ee931e8)

🐛 Type oppgave: Bug

🥅 Mål med PRen: Fikse sånn at vi alltid rendrer kodeblokker riktig

## Løsning

🆕 Endring: Se over

#️⃣ Punktliste av hva som er endret:

- Lagt kodesnutten inn i en state-variabel. 
