### PR TITLE
add ingress to luke page for mobile

### DIFF
--- a/web/app/features/post-preview/PostPreview.tsx
+++ b/web/app/features/post-preview/PostPreview.tsx
@@ -87,6 +87,7 @@ export const PostPreview = ({
           </div>
         )}
       </div>
+      {summary && <p className="sm:hidden mt-2 text-sm line-clamp-3">{summary}</p>}
     </motion.div>
   )
   if (link) {


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Legge-til-ingress-p-lukesiden-p-mobil-1506bd308541807d9aa8ea1bd3088447?pvs=4)

💄 STYLING

🥅 Mål med PRen: Legge til ingress på lukesiden på mobil

## 🧪 Testing

Ser det greit ut? Er det nok margin? 

## Bilder
<img width="360" alt="image" src="https://github.com/user-attachments/assets/9d378864-142f-4223-84f0-ff47bea31c0a">