### PR TITLE
add reading time to podcasts

### DIFF
--- a/web/app/features/post-preview/PostPreview.tsx
+++ b/web/app/features/post-preview/PostPreview.tsx
@@ -32,7 +32,7 @@ export const PostPreview = ({
   podcastLength,
   link,
 }: PostPreviewProps) => {
-  const showReadingTime = wordCount !== null && podcastLength === null
+  const showReadingTime = wordCount !== null || podcastLength !== null
   const content = (
     <motion.div
       className="striped-frame py-6 px-6 sm:p-7"


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Vise-lengde-p-podcast-p-lukeside-1526bd30854180ccaeb7dea8d5ea4a02?pvs=4)

🛠️  FIKS

🥅 Mål med PRen: Vise reading time på podcaster 

## Løsning

- Måtte bare endre sjekken på når man skulle vise reading time 

## Testing 

Har sjekka gjennom artiklene fra 2024 og 2023 og det ser ut til å funke, men gjerne sjekk litt andre steder også
