### PR TITLE
remove articles without content

### DIFF
--- a/web/utils/sanity/queries/postQueries.ts
+++ b/web/utils/sanity/queries/postQueries.ts
@@ -117,7 +117,7 @@ export const ARTICLE_CONTENT_BY_ID = defineQuery(
   }`
 )
 export const POSTS_BY_YEAR_AND_DATE = defineQuery(
-  `*[_type == "post" && availableFrom == $date] | order(priority desc) ${POST_PREVIEW_PROJECTION}`
+  `*[_type == "post" && availableFrom == $date && (length(string::split(pt::text(content), ' ')) > 0 || podcastLength != null)] | order(priority desc) ${POST_PREVIEW_PROJECTION}`
 )
 export const ALL_CATEGORIES = defineQuery(`*[_type == "tag"] | order(name asc)`)
 export const TAG_WITH_POSTS_QUERY = defineQuery(`{


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Ikke-vise-artikler-som-ikke-har-noe-content-1526bd30854180608acddc272eed78c9?pvs=4)

🛠️  FIKS

🥅 Mål med PRen: Fjerne artikler som ikke har noe content 

## Løsning
Noen av artiklene som ligger ute har null content som f.eks. [denne](https://www.bekk.christmas/post/2023/09/ux-is-going-awry-what-if-we-blew-it)

- Endret groq-kallet til å sjekke om podcastlength er ulik null eller wordcount er større enn null for å filtrere bort disse

## 🧪 Testing

Har sjekka at alle artiklene fra 2024 (som har kommet ut) fortsatt vises, samt alle fra 2023 som ikke har null content, men gjerne sjekk litt til hvis dere gidder.
