### PR TITLE
fix/image bug

### DIFF
--- a/web/app/features/article/PostStamp.tsx
+++ b/web/app/features/article/PostStamp.tsx
@@ -14,6 +14,7 @@ const useValidatedImageUrl = (image: NonNullable<POST_BY_SLUGResult>['coverImage
   const [validatedUrl, setValidatedUrl] = useState<string | null>(null)
 
   useEffect(() => {
+    if (!image) return
     const validateUrl = async () => {
       const url = image?.asset
         ? urlFor(image.asset as SanityAsset)


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Noen-steder-s-klarer-man-ikke-hente-bildet-til-lukesiden-1526bd30854180df95aef41d26601ce7?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Noen steder blir ikke frimerke vist når det ikke finnes noe bilde 

## Løsning

🆕 Endring: I dette tilfellet var det artikler som ikke hadde coverbilde, men kun lenke til bilde. Og bilde på denne lenken finnes ikke lenger, som gjorde at det ble vist stygt default bilde. Løser det med å sjekke om vi klarer å loade bilde før vi setter det. Har laget en hook som gjør dette samt setter imgUrl. Si ifra hvis du kommer på en bedre løsning på dette her🙏🏻

## 🧪 Testing

Test ulike lukesider, samt kategorisider og forfattersider og se om det blir vist enten coverbilde eller frimerke. Håper ingenting krasjer🙏🏻 

## Bilder
eksempel fra kategori/kotlin

**Før:**
<img width="730" alt="image" src="https://github.com/user-attachments/assets/53fd09ae-365f-4140-8bc7-c34e92b7a5b7">

**Etter:**
<img width="667" alt="image" src="https://github.com/user-attachments/assets/5872e41a-a1b5-426a-a657-300b38305486">

