### PR TITLE
Nytt forsøk på å fikse kodeeditor 🤞 

### DIFF
--- a/web/app/features/teaser/TeaserPage.tsx
+++ b/web/app/features/teaser/TeaserPage.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useState } from 'react'
 import Countdown, { CountdownRendererFn } from 'react-countdown'
 import { Link } from '@remix-run/react'
 
 import { PostPreview } from '../post-preview/PostPreview'
 
 import { LinkToArchive } from '~/components/LinkToArchive'
-
-const useClientSideOnly = () => {
-  const [isClientSide, setIsClientSide] = useState(false)
-  useEffect(() => {
-    setIsClientSide(true)
-  }, [])
-  return isClientSide
-}
+import useClientSideOnly from '~/hooks/useClientSideOnly'
 
 interface CountdownRendererFnProps {
   days: number

--- a/web/app/hooks/useClientSideOnly.ts
+++ b/web/app/hooks/useClientSideOnly.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react'
+
+const useClientSideOnly = () => {
+  const [isClientSide, setIsClientSide] = useState(false)
+  useEffect(() => {
+    setIsClientSide(true)
+  }, [])
+  return isClientSide
+}
+
+export default useClientSideOnly

--- a/web/app/portable-text/CodeBlock.tsx
+++ b/web/app/portable-text/CodeBlock.tsx
@@ -1,31 +1,29 @@
-import { useEffect, useState } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 
 import { Code } from '../../utils/sanity/types/sanity.types'
+
+import useClientSideOnly from '~/hooks/useClientSideOnly'
 
 interface CodeBlockProps {
   code: Code
 }
 export const CodeBlock = ({ code }: CodeBlockProps) => {
-  // Denne 'unødvendige' state-variabelen er en workaround for å unngå dette: https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/538
-  const [codeState, setCodeState] = useState<string | undefined>()
+  const isClientSide = useClientSideOnly()
 
-  useEffect(() => {
-    if (code.code) {
-      setCodeState(code.code)
-    }
-  }, [code.code])
-
-  if (!codeState) {
+  if (!code.code) {
     return null
   }
 
   return (
     <div className="codeBlockColorOverride text-sm max-w-[800px] overflow-hidden rounded-md">
       <div className="overflow-x-auto bg-gray-50">
-        <SyntaxHighlighter customStyle={{ backgroundColor: 'transparent' }} language={code.language ?? 'text'}>
-          {codeState}
-        </SyntaxHighlighter>
+        {isClientSide ? (
+          <SyntaxHighlighter customStyle={{ backgroundColor: 'transparent' }} language={code.language ?? 'text'}>
+            {code.code}
+          </SyntaxHighlighter>
+        ) : (
+          <code>{code.code}</code>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Bug-i-kodeeditor-Object-object-14c6bd30854180e88278d40c2ee931e8)

🐛 Type oppgave: Bug

🥅 Mål med PRen: Fikse feil i kodeeditor som blir [Object object]...

## Løsning

🆕 Endring: Kun rendre syntaxhighlighteren på klientsiden. På server rendrere vi bare en <code />-tag

- Flyttet ut `useClientSideOnly()`-hooken i en egen fil, da jeg trengte den her. 
