### PR TITLE
add article type to luke preview

### DIFF
--- a/web/app/features/post-preview/PostPreview.tsx
+++ b/web/app/features/post-preview/PostPreview.tsx
@@ -76,7 +76,7 @@ export const PostPreview = ({
           )}
           {showReadingTime && (
             <>
-              {type == 'article' ? 'Artikkel' : type == 'podcast' ? 'Podcast' : 'Video'}{' '}
+              {type == 'article' ? 'Artikkel' : type == 'podcast' ? 'Podkast' : 'Video'}{' '}
               {podcastLength ? ` (${podcastLength} min)` : wordCount ? ` (${readingTime(wordCount)})` : null}
               <div className="sm:mb-7 border-b border-bekk-night pb-1 mb-3" />
             </>

--- a/web/app/features/post-preview/PostPreview.tsx
+++ b/web/app/features/post-preview/PostPreview.tsx
@@ -18,6 +18,7 @@ type PostPreviewType = {
   wordCount: number | null
   podcastLength: number | null
   link?: string
+  type: string
 }
 
 type PostPreviewProps = PostPreviewType
@@ -31,6 +32,7 @@ export const PostPreview = ({
   wordCount,
   podcastLength,
   link,
+  type,
 }: PostPreviewProps) => {
   const showReadingTime = wordCount !== null && podcastLength === null
   const content = (
@@ -74,7 +76,8 @@ export const PostPreview = ({
           )}
           {showReadingTime && (
             <>
-              {podcastLength ? `${podcastLength} min` : wordCount ? readingTime(wordCount) : null}
+              {type == 'article' ? 'Artikkel' : type == 'podcast' ? 'Podcast' : 'Video'}{' '}
+              {podcastLength ? ` (${podcastLength} min)` : wordCount ? ` (${readingTime(wordCount)})` : null}
               <div className="sm:mb-7 border-b border-bekk-night pb-1 mb-3" />
             </>
           )}

--- a/web/utils/sanity/queries/postQueries.ts
+++ b/web/utils/sanity/queries/postQueries.ts
@@ -31,6 +31,7 @@ const POST_PREVIEW_PROJECTION = groq`{
   "summary": coalesce(previewText, pt::text(description)),
   "wordCount": length(string::split(pt::text(content), ' ')),
   podcastLength,
+  type,
 }`
 export const ALL_POSTS = groq`*[_type == "post"]`
 const POST_PROJECTION = groq`{


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Legge-til-hva-slags-type-artikkel-det-er-p-lukesiden-1526bd30854180639854cdda36142dd5?pvs=4)

💄 STYLING

🥅 Mål med PRen: Legge til hvilken type artikkel det er på preview av artikkel

## Løsning
- Lagt til type i sanity-kallet så vi kan hente ut hva slags artikkel det er (video vs artikkel vs podcast)

## Bilder
<img width="927" alt="image" src="https://github.com/user-attachments/assets/42222c48-80d7-4653-98ac-f4ed24397ab7">
