### PR TITLE
align meta and content

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -108,7 +108,7 @@ export const Article = ({ post }: ArticleProps) => {
       </div>
       <div className="flex flex-col col-start-2 col-end-2 row-start-2 row-end-2 max-md:max-w-screen-xl max-lg:max-w-[475px] max-2lg:max-w-[550px] 2lg:max-w-[675px] xl:pr-10 xl:max-w-3xl 2xl:max-w-4xl">
         {post?.description ? (
-          <div className="text-xl">
+          <div className="text-xl remove-margin">
             <PortableText value={post.description} components={components} />
           </div>
         ) : null}
@@ -138,7 +138,7 @@ export const Article = ({ post }: ArticleProps) => {
           </div>
         )}
         {post.content && (
-          <div className="leading-8">
+          <div className="remove-margin leading-8">
             <PortableText value={post.content} components={components} />
           </div>
         )}

--- a/web/app/styles/main.css
+++ b/web/app/styles/main.css
@@ -168,3 +168,7 @@
   clip-path: polygon(5% 0, 95% 0, 100% 20%, 100% 80%, 95% 100%, 5% 100%, 0 80%, 0 20%);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3); /* Optional: add shadow for depth */
 }
+
+.remove-margin p:first-of-type {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Aligne-meta-og-content-p-artikkelside-1526bd3085418093a3abecce07771fa6?pvs=4)

💄 STYLING

🥅 Mål med PRen: Aligne meta og artikkelcontent 

- Litt hacky løsning med å fjerne padding fra ingress eller content på første p-taggen innenfor den div-en 

## Bilder
FØR 
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/f1a5a5e8-2147-4e43-9526-4a5258caa797">
ETTER 
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/87e3f334-c389-4324-a403-bab5c7f8d2e7">
