### PR TITLE
add cache to author and category sanity calls

### DIFF
--- a/web/app/routes/forfatter.$name.tsx
+++ b/web/app/routes/forfatter.$name.tsx
@@ -32,15 +32,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw new Response('Author not found', { status: 404 })
   }
 
-  return json({
-    posts: response.data.posts || [],
-    author: response.data.author,
-    pagination: {
-      currentPage: page,
-      totalPages: Math.ceil((response.data.totalCount || 0) / perPage),
-      totalPosts: response.data.totalCount || 0,
+  return json(
+    {
+      posts: response.data.posts || [],
+      author: response.data.author,
+      pagination: {
+        currentPage: page,
+        totalPages: Math.ceil((response.data.totalCount || 0) / perPage),
+        totalPosts: response.data.totalCount || 0,
+      },
     },
-  })
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=3600',
+      },
+    }
+  )
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/web/app/routes/kategori.$tag.tsx
+++ b/web/app/routes/kategori.$tag.tsx
@@ -31,15 +31,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw new Response('No category with this name', { status: 404 })
   }
 
-  return json({
-    posts: response.data.posts || [],
-    tag: response.data.tag,
-    pagination: {
-      currentPage: page,
-      totalPages: Math.ceil((response.data.totalCount || 0) / perPage),
-      totalPosts: response.data.totalCount || 0,
+  return json(
+    {
+      posts: response.data.posts || [],
+      tag: response.data.tag,
+      pagination: {
+        currentPage: page,
+        totalPages: Math.ceil((response.data.totalCount || 0) / perPage),
+        totalPosts: response.data.totalCount || 0,
+      },
     },
-  })
+    {
+      headers: {
+        'Cache-Control': 'public, max-age=60, s-maxage=60, stale-while-revalidate=3600',
+      },
+    }
+  )
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Cache-kategoriartikler-og-forfatterartikler-1526bd30854180eaaa8defc5c4bf8c3f?pvs=4)

⚒️ FIKS

🥅 Mål med PRen: Cache sanity kall

## Løsning
Tydeligvis så selv om vi har cache headers i root, så er det kun på selve html-dokumentet og ikke på kall gjort i loaderfunksjonen. Vet ikke om det er dumt å cache det i det hele tatt? 

- Satte en cacheheader i loaderfunksjonen til både forfatter og kategori-siden slik at dette forhåpentligvis er litt smudere for leser hvis man trykker seg litt fram og tilbake 

## 🧪 Testing
Tror ikke dette skal overskrive security-headers fra root, men litt usikker

