### PR TITLE
Fiks bug med utlistning av serier

### DIFF
--- a/web/utils/sanity/queries/postQueries.ts
+++ b/web/utils/sanity/queries/postQueries.ts
@@ -98,7 +98,7 @@ const POST_PROJECTION = groq`{
     description,
     slug,
     shouldListNonPublishedContent,
-    "posts": *[_type == "post" && references(^._id) && availableFrom < now() && !(availableFrom match "*25")] | order(availableFrom asc) {
+    "posts": *[_type == "post" && references(^._id)] | order(availableFrom asc) {
       _id,
       title,
       availableFrom,


### PR DESCRIPTION
## Beskrivelse

Logikken rundt serieutlistning tok høyde for at man returnerte alle artiklene, med GROQen filtrerte ut de som ikke var publisert. 

Denne PRen gjør at vi henter ut alle artikler i en serie, og filtrerer dem på serveren istedenfor i databasen – det gjør det enklere uten å bli altfor mye treigere.