### PR TITLE
Ikke cache feilsituasjoner

### DIFF
--- a/web/app/routes/forfatter.$name.tsx
+++ b/web/app/routes/forfatter.$name.tsx
@@ -13,7 +13,12 @@ import { PostPreviewList } from '~/features/post-preview/PostPreview'
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const { name } = params
   if (!name) {
-    throw new Response('Missing author', { status: 404 })
+    throw new Response('Missing author', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   // Get page from URL search params
@@ -29,7 +34,12 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   })
 
   if (!response.data.author) {
-    throw new Response('Author not found', { status: 404 })
+    throw new Response('Author not found', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   return {

--- a/web/app/routes/kategori.$tag.tsx
+++ b/web/app/routes/kategori.$tag.tsx
@@ -28,7 +28,12 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   })
 
   if (!response.data || !response.data.tag) {
-    throw new Response('No category with this name', { status: 404 })
+    throw new Response('No category with this name', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   return {

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -73,7 +73,12 @@ const ParamsSchema = z.object({
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const parsedParams = ParamsSchema.safeParse(params)
   if (!parsedParams.success) {
-    throw new Response('Invalid params', { status: 400 })
+    throw new Response('Invalid params', {
+      status: 400,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
   const { year, date, slug } = parsedParams.data
 
@@ -87,17 +92,37 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const dateNumber = parseInt(date, 10)
 
   if (!preview && (isNaN(dateNumber) || dateNumber < 1 || dateNumber > 24)) {
-    throw new Response('Date not found', { status: 404 })
+    throw new Response('Date not found', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   if (!preview && currentDate < targetDate) {
-    throw new Response('Date not yet available', { status: 425 })
+    throw new Response('Date not yet available', {
+      status: 425,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
   if (!initial.data) {
-    throw new Response('Post not found', { status: 404 })
+    throw new Response('Post not found', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
   if (!preview && initial.data.availableFrom !== formatDate) {
-    throw new Response('Post date and date in url do not match', { status: 404 })
+    throw new Response('Post date and date in url do not match', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   const imageUrl = initial.data.coverImage?.asset

--- a/web/app/routes/post.$year.$date.tsx
+++ b/web/app/routes/post.$year.$date.tsx
@@ -53,12 +53,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   const dateNumber = parseInt(date, 10)
   if (!preview && (isNaN(dateNumber) || dateNumber < 1 || dateNumber > 24)) {
-    throw new Response('Date not found', { status: 404 })
+    throw new Response('Date not found', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   const targetDate = new Date(formatDate)
   if (!preview && currentDate < targetDate) {
-    throw new Response('Date not yet available', { status: 425 })
+    throw new Response('Date not yet available', {
+      status: 425,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
 
   try {

--- a/web/app/routes/post.$year.tsx
+++ b/web/app/routes/post.$year.tsx
@@ -24,10 +24,20 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const paramsYearAsNumber = Number.parseInt(year)
 
   if (isNaN(paramsYearAsNumber) || paramsYearAsNumber < 2017) {
-    throw new Response('Invalid year', { status: 404 })
+    throw new Response('Invalid year', {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
   if (paramsYearAsNumber > currentYear) {
-    throw new Response('Year not yet available', { status: 425 })
+    throw new Response('Year not yet available', {
+      status: 425,
+      headers: {
+        'Cache-Control': 'no-cache, no-store',
+      },
+    })
   }
   return { year }
 }


### PR DESCRIPTION
## Beskrivelse

Denne PRen legger til "no-cache, no-store" cache-control header direktiver på alle feilsituasjoner. Det vil si – hvis man får en 404-feil, så cacher man ikke den feilen, men sjekker på nytt igjen hver gang. I dag setter vi bare default headerne om man får en feil, som fører til at feil caches i en time 😬 

Om caching headers og caching-direktiver er litt kryptisk for deg, så forklarer Chat GPT forskjellen på de to forskjellige direktivene slik:

> no-store og no-cache i Cache-Control-headeren styrer hvordan ressurser håndteres i nettlesere og mellomlagre. Med no-store instrueres klienter og mellomlagre om aldri å lagre dataen, verken i minnet eller på disk. Dette sikrer at sensitive data, som brukerinformasjon eller betalingstransaksjoner, alltid hentes direkte fra serveren uten risiko for at de blir liggende i et cache. Det eliminerer all lokal lagring og krever en ny forespørsel for hver eneste tilgang.

> no-cache derimot tillater mellomlagring, men krever at lagrede ressurser valideres mot serveren før de brukes. Dette gir en balanse mellom effektivitet og ferskhet, siden ressursen bare lastes ned på nytt hvis serveren bekrefter at den har endret seg (typisk ved hjelp av ETag eller Last-Modified). no-store gir full kontroll på datasikkerhet, mens no-cache er ideelt for data som oppdateres regelmessig, men som ikke nødvendigvis må hentes på nytt hver gang.

Eller, som et lite dikt:

> I cachen ligger intet fast
> Med no-store slettes alt hver gang
> Ingen lagring, ingen last
> Serveren svarer, aldri en gang kast
> Med no-cache må du spørre, en ny klang.