### PR TITLE
Slå av preview mode om cookie ikke er satt

### DIFF
--- a/web/utils/sanity/config.ts
+++ b/web/utils/sanity/config.ts
@@ -1,6 +1,6 @@
 export const sanityConfig = {
-  projectId: process.env.SANITY_STUDIO_PROJECT_ID,
+  projectId: process.env.SANITY_STUDIO_PROJECT_ID ?? 'ah2n1vfr',
   dataset: process.env.SANITY_STUDIO_DATASET ?? 'bekk-blogg',
   useCdn: process.env.NODE_ENV === 'production',
-  apiVersion: process.env.SANITY_API_VERSION,
+  apiVersion: process.env.SANITY_API_VERSION ?? '2024-12-09',
 }

--- a/web/utils/sanity/loadQueryOptions.server.ts
+++ b/web/utils/sanity/loadQueryOptions.server.ts
@@ -7,7 +7,12 @@ export async function loadQueryOptions(
   headers: Headers
 ): Promise<{ preview: boolean; options: Parameters<typeof loadQuery>[2] }> {
   const previewSession = await getSession(headers.get('Cookie'))
-  const preview = previewSession.get('projectId') === readClient.config().projectId
+  const preview = previewSession.get('projectId') && previewSession.get('projectId') === readClient.config().projectId
+  console.log('tmp logging', {
+    preview,
+    projectId: readClient.config().projectId,
+    fromCookie: previewSession.get('projectId'),
+  })
 
   if (preview && !process.env.SANITY_READ_API_TOKEN) {
     throw new Error(

--- a/web/utils/sanity/loadQueryOptions.server.ts
+++ b/web/utils/sanity/loadQueryOptions.server.ts
@@ -19,6 +19,7 @@ export async function loadQueryOptions(
     preview,
     options: {
       perspective: preview ? 'previewDrafts' : 'published',
+      useCdn: preview ? false : process.env.NODE_ENV === 'production',
       stega: preview ? { enabled: true, studioUrl: process.env.SANITY_STUDIO_URL } : undefined,
     },
   }

--- a/web/utils/sanity/loadQueryOptions.server.ts
+++ b/web/utils/sanity/loadQueryOptions.server.ts
@@ -8,11 +8,6 @@ export async function loadQueryOptions(
 ): Promise<{ preview: boolean; options: Parameters<typeof loadQuery>[2] }> {
   const previewSession = await getSession(headers.get('Cookie'))
   const preview = previewSession.get('projectId') && previewSession.get('projectId') === readClient.config().projectId
-  console.log('tmp logging', {
-    preview,
-    projectId: readClient.config().projectId,
-    fromCookie: previewSession.get('projectId'),
-  })
 
   if (preview && !process.env.SANITY_READ_API_TOKEN) {
     throw new Error(


### PR DESCRIPTION
## Beskrivelse

Ser ut til at preview mode ofte blir slått på i prod selv om man ikke har noen cookies. Jeg tror det kanskje er fordi sanity-klienten ikke får inn den informasjonen den trenger i disse kontekstene, men er usikker.

Legger derfor på litt ekstra "skallsikring", slik at det skal være nærmere umulig å få opp preview mode om man ikke skal. Men må debugge litt, så derfor er det litt console logs med i PRen. Disse blir tatt vekk før merge.