### PR TITLE
🐛 Bruke riktig bakgrunn på artikkelside

### DIFF
--- a/web/app/routes/post.$year.tsx
+++ b/web/app/routes/post.$year.tsx
@@ -76,7 +76,7 @@ export default function YearRoute() {
   const data = useLoaderData<{ year: string }>()
 
   return (
-    <div className="bg-brick-wall-with-wooden-plank">
+    <div className="bg-brick-wall">
       <div className="2lg:h-screen flex flex-col justify-end items-center min-h-screen">
         <SnowAnimation />
         <Link to="/post/2024" className="absolute top-[20px] md:top-[40px] right-[20px] md:right-[40px]">


### PR DESCRIPTION
## Beskrivelse

💳 Lenke til [Notionkort](https://www.notion.so/bekks/Planke-i-toppen-1576bd3085418051b66cea89613554d0?pvs=4)

🐛 Type oppgave: bug

🥅 Mål med PRen: Feil bakgrunn ble brukt på artikkelside, så den store planken kom i toppen

## Løsning

#️⃣ Punktliste av hva som er endret:

- Endret bakgrunn til å kun bruke brick wall (uten wooden plank)

## Bilder


**Før:**
![image](https://github.com/user-attachments/assets/9ef843f2-0bcf-4000-ab42-90651b8d76f3)

**Etter:**
![image](https://github.com/user-attachments/assets/cf441fe0-f627-495d-b385-8ffcda7d977d)
