### PR TITLE
Fiks preview igjen

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -10,7 +10,6 @@ import {
   useMatches,
   useRouteError,
 } from '@remix-run/react'
-import { VisualEditing } from '@sanity/visual-editing/remix'
 import type { HeadersFunction, LinksFunction, LoaderFunction } from '@vercel/remix'
 import { SpeedInsights } from '@vercel/speed-insights/remix'
 import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
@@ -124,6 +123,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
 const ExitPreview = lazy(() =>
   import('./components/ExitPreview').then((module) => ({
     default: module.ExitPreview,
+  }))
+)
+
+const VisualEditing = lazy(() =>
+  import('@sanity/visual-editing/remix').then((module) => ({
+    default: module.VisualEditing,
   }))
 )
 

--- a/web/app/routes/resource.preview.tsx
+++ b/web/app/routes/resource.preview.tsx
@@ -37,7 +37,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 
   const session = await getSession(request.headers.get('Cookie'))
-  await session.set('projectId', readClient.config().projectId)
+  session.set('projectId', readClient.config().projectId)
 
   return redirect(redirectTo, {
     headers: {

--- a/web/utils/sanity/loadQueryOptions.server.ts
+++ b/web/utils/sanity/loadQueryOptions.server.ts
@@ -8,6 +8,10 @@ export async function loadQueryOptions(
 ): Promise<{ preview: boolean; options: Parameters<typeof loadQuery>[2] }> {
   const previewSession = await getSession(headers.get('Cookie'))
   const preview = previewSession.get('projectId') && previewSession.get('projectId') === readClient.config().projectId
+  console.log({
+    sessionProjectId: previewSession.get('projectId'),
+    clientProjectId: readClient.config().projectId,
+  })
 
   if (preview && !process.env.SANITY_READ_API_TOKEN) {
     throw new Error(


### PR DESCRIPTION
## Beskrivelse

Så det viser seg at når vi er i Sanity preview mode i prod, så lastes ikke VisualEditing komponenten. Det kommer mest sannsynlig fra at vi returnerer ganske harde cache headers på rotnivå uansett.

Denne PRen returnerer "riktige" cache headers basert på om man er i preview modus eller ei. Også legger jeg på litt logging for å dobbeltsjekke at dette stemmer. 