### PR TITLE
Bruk data istedenfor den deprekerte json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "bekk-blogg",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense } from 'react'
 import {
   isRouteErrorResponse,
-  json,
   Links,
   Meta,
   Outlet,
@@ -11,7 +10,7 @@ import {
   useMatches,
   useRouteError,
 } from '@remix-run/react'
-import type { HeadersFunction, LinksFunction, LoaderFunction } from '@vercel/remix'
+import { data, HeadersFunction, LinksFunction, LoaderFunction } from '@vercel/remix'
 import { SpeedInsights } from '@vercel/speed-insights/remix'
 import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
 import { generateSecurityHeaders } from 'utils/security'
@@ -25,7 +24,7 @@ export const links: LinksFunction = () => [{ rel: 'stylesheet', href: styles }]
 
 export const loader: LoaderFunction = async ({ request }) => {
   const { preview } = await loadQueryOptions(request.headers)
-  return json({
+  return data({
     isPreview: preview,
     ENV: {
       SANITY_STUDIO_PROJECT_ID: process.env.SANITY_STUDIO_PROJECT_ID,

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -1,6 +1,7 @@
-import { isRouteErrorResponse, json, redirect, useLoaderData, useRouteError } from '@remix-run/react'
+import { isRouteErrorResponse, redirect, useLoaderData, useRouteError } from '@remix-run/react'
 import { useQuery } from '@sanity/react-loader'
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@vercel/remix'
+import { data } from '@vercel/remix'
 import { cleanControlCharacters } from 'utils/controlCharacters'
 import { combinedHeaders } from 'utils/headers'
 import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
@@ -19,7 +20,7 @@ import { Article } from '~/features/article/Article'
 import Header from '~/features/header/Header'
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
-  const post = data?.initial.data
+  const post = data?.data.initial.data
 
   if (!post) {
     return []
@@ -134,7 +135,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     ? urlFor(initial.data.coverImage).width(1200).format('webp').url()
     : undefined
 
-  return json(
+  return data(
     { initial, query: POST_BY_SLUG, params: parsedParams.data, imageUrl },
     {
       status: 200,
@@ -179,7 +180,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 export const headers = combinedHeaders
 
 export default function ArticleRoute() {
-  const { initial, query, params } = useLoaderData<typeof loader>()
+  const {
+    data: { initial, query, params },
+  } = useLoaderData<typeof loader>()
   const { data } = useQuery<typeof initial.data>(query, params, {
     // @ts-expect-error Dette er en kjent bug i sanity-react-loader
     initial,


### PR DESCRIPTION
## Beskrivelse

`json` funksjonen fra remix er deprecated. Nå kan du returnere data direkte med tomme objekter. MEN – om du skal returnere data OG sette headers, ja, da må du bruke [`data`](https://remix.run/docs/en/main/utils/data) istedenfor.

Denne PRen bytter ut de to stedene i løsningen vi brukte `json` fortsatt.