### PR TITLE
Legg til støtte for tabeller

### DIFF
--- a/sanity/package-lock.json
+++ b/sanity/package-lock.json
@@ -13,6 +13,7 @@
         "@sanity/code-input": "^4.1.4",
         "@sanity/locale-nb-no": "^1.1.16",
         "@sanity/structure": "^2.36.2",
+        "@sanity/table": "^1.1.2",
         "@sanity/vision": "^3.61.0",
         "get-youtube-id": "^1.0.1",
         "react": "^18.2.0",
@@ -4815,6 +4816,37 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@sanity/table": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@sanity/table/-/table-1.1.2.tgz",
+      "integrity": "sha512-VTQQYtuYXRYnrwPeQDDYQ0/MExroV4FDeJStpxW3JcYWj+dKvfMfXG5PebzqgbolhAIzgYwcmkOBMXwmwEAN7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^2.0.0",
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18",
+        "react-dom": "^18",
+        "sanity": "^3.0.0"
+      }
+    },
+    "node_modules/@sanity/table/node_modules/@sanity/icons": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-2.11.8.tgz",
+      "integrity": "sha512-C4ViXtk6eyiNTQ5OmxpfmcK6Jw+LLTi9zg9XBUD15DzC4xTHaGW9SVfUa43YtPGs3WC3M0t0K59r0GDjh52HIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18"
       }
     },
     "node_modules/@sanity/telemetry": {

--- a/sanity/package.json
+++ b/sanity/package.json
@@ -20,6 +20,7 @@
     "@sanity/code-input": "^4.1.4",
     "@sanity/locale-nb-no": "^1.1.16",
     "@sanity/structure": "^2.36.2",
+    "@sanity/table": "^1.1.2",
     "@sanity/vision": "^3.61.0",
     "get-youtube-id": "^1.0.1",
     "react": "^18.2.0",

--- a/sanity/sanity.config.ts
+++ b/sanity/sanity.config.ts
@@ -1,5 +1,6 @@
 import {codeInput} from '@sanity/code-input'
 import {nbNOLocale} from '@sanity/locale-nb-no'
+import {table} from '@sanity/table'
 import {visionTool} from '@sanity/vision'
 import {createAuthStore, defineConfig, SchemaTypeDefinition} from 'sanity'
 import {media} from 'sanity-plugin-media'
@@ -26,6 +27,7 @@ const config = defineConfig({
     visionTool(),
     media(),
     codeInput(),
+    table(),
     presentationTool({
       devMode: process.env.NODE_ENV !== 'production',
       previewUrl: {

--- a/sanity/schemas/objects/portableText.tsx
+++ b/sanity/schemas/objects/portableText.tsx
@@ -15,6 +15,7 @@ const portableText = defineType({
   type: 'array',
   title: 'Post body',
   of: [
+    {type: 'table'},
     {
       type: 'block',
       title: 'Block',

--- a/web/app/components/ui/table.tsx
+++ b/web/app/components/ui/table.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+
+import { cn } from '~/lib/utils'
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+)
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+)
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  )
+)
+TableBody.displayName = 'TableBody'
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)} {...props} />
+  )
+)
+TableFooter.displayName = 'TableFooter'
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)}
+      {...props}
+    />
+  )
+)
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement> & { className?: string }
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement> & { className?: string }
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+  )
+)
+TableCaption.displayName = 'TableCaption'
+
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow }

--- a/web/app/lib/utils.ts
+++ b/web/app/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/web/app/portable-text/Components.tsx
+++ b/web/app/portable-text/Components.tsx
@@ -27,6 +27,7 @@ import { UnfurledUrlBlock } from './UnfurledUrlBlock'
 import { YouTubeBlock } from './YouTubeBlock'
 
 import { TextLink } from '~/components/TextLink'
+import { TableBlock } from './TableBlock'
 
 const withSpacing = (component: React.ReactNode, margin: number = 2) => {
   return <div style={{ marginTop: `${margin}rem`, marginBottom: `${margin}rem` }}>{component}</div>
@@ -47,6 +48,7 @@ export const components: Partial<PortableTextReactComponents> = {
       withSpacing(<InfoBlock content={props.value.content as PortableText} />),
     quote: (props: { value: Quote }) =>
       withSpacing(<QuoteBlock quote={props.value.content} author={props.value.author} />),
+    table: (props: { value: { rows: { cells: string[] }[] } }) => withSpacing(<TableBlock data={props.value} />),
   },
   block: {
     h1: ({ children }: { children?: React.ReactNode }) => <h1 className="mb-6 mt-12 leading-none">{children}</h1>,

--- a/web/app/portable-text/TableBlock.tsx
+++ b/web/app/portable-text/TableBlock.tsx
@@ -1,0 +1,27 @@
+import { Table, TableBody, TableCell, TableRow } from '~/components/ui/table'
+
+type TableProps = {
+  data: {
+    rows: { cells: string[] }[]
+  }
+}
+export const TableBlock = ({ data }: TableProps) => {
+  if (!data.rows?.length) {
+    return null
+  }
+  return (
+    <div className="overflow-x-auto">
+      <Table className="table-auto w-full text-sm">
+        <TableBody>
+          {data.rows.map((row, index) => (
+            <TableRow key={index}>
+              {row.cells.map((cell, cellIndex) => (
+                <TableCell key={cellIndex}>{cell}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/web/app/styles/fonts.css
+++ b/web/app/styles/fonts.css
@@ -86,4 +86,66 @@
     font-style: normal;
     font-display: swap;
   }
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+    --radius: 0.5rem;
+  }
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
 }

--- a/web/components.json
+++ b/web/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/styles/fonts.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "~/components",
+    "utils": "~/lib/utils",
+    "ui": "~/components/ui",
+    "lib": "~/lib",
+    "hooks": "~/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@vercel/remix": "^2.15.0",
         "@vercel/speed-insights": "^1.1.0",
         "algoliasearch": "^4.10.5",
-        "class-variance-authority": "^0.7.0",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "csp-header": "^5.2.1",
         "get-youtube-id": "^1.0.1",
@@ -44,7 +44,7 @@
         "remix-auth-microsoft": "^2.0.1",
         "sanity": "^3.62.3",
         "sanity-algolia": "^1.1.0",
-        "tailwind-merge": "^2.5.4",
+        "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
       },
@@ -7674,22 +7674,15 @@
       }
     },
     "node_modules/class-variance-authority": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
-      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "clsx": "2.0.0"
+        "clsx": "^2.1.1"
       },
       "funding": {
-        "url": "https://joebell.co.uk"
-      }
-    },
-    "node_modules/class-variance-authority/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/classnames": {
@@ -7799,6 +7792,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -13245,6 +13239,7 @@
       "version": "0.454.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.454.0.tgz",
       "integrity": "sha512-hw7zMDwykCLnEzgncEEjHeA6+45aeEzRYuKHuyRSOPkhko+J3ySGjGIzu+mmMfDFG1vazHepMaYFYHbTFAZAAQ==",
+      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
@@ -19420,9 +19415,10 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/tailwind-merge": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.4.tgz",
-      "integrity": "sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.5.tgz",
+      "integrity": "sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -19468,6 +19464,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
       "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "@vercel/remix": "^2.15.0",
     "@vercel/speed-insights": "^1.1.0",
     "algoliasearch": "^4.10.5",
-    "class-variance-authority": "^0.7.0",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "csp-header": "^5.2.1",
     "get-youtube-id": "^1.0.1",
@@ -53,7 +53,7 @@
     "remix-auth-microsoft": "^2.0.1",
     "sanity": "^3.62.3",
     "sanity-algolia": "^1.1.0",
-    "tailwind-merge": "^2.5.4",
+    "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"
   },

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -49,7 +49,7 @@ export default {
       },
       screens: {
         sm: '640px',
-        '2sm': '832px', // for spotify embed
+        '2sm': '832px',
         md: '900px',
         lg: '1024px',
         '2lg': '1130px',
@@ -57,9 +57,9 @@ export default {
         '2xl': '1536px',
       },
       borderWidth: {
-        DEFAULT: '1px',
         '14': '14px',
         '30': '30px',
+        DEFAULT: '1px',
       },
       borderColor: {
         'reindeer-brown': '#714319',
@@ -114,6 +114,7 @@ export default {
           '4': 'hsl(var(--chart-4))',
           '5': 'hsl(var(--chart-5))',
         },
+        background: 'hsl(var(--background))',
       },
     },
   },


### PR DESCRIPTION
## Beskrivelse
Preben ville gjerne ha tabeller for en av artiklene sine. Så da legger vi til tabeller!

Sanity har sin egen tabell-plugin, og så brukte jeg shadcn til å rendre tabeller

<img width="797" alt="image" src="https://github.com/user-attachments/assets/ba464361-95cc-4dba-9adc-25eb74bec320" />
