### PR TITLE
Filtrer ut upubliserte artikler ved henting fra algolia

### DIFF
--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -224,7 +224,7 @@ export default function ArticleRoute() {
                 <DoorSign>Relaterte artikler</DoorSign>
               </div>
             )}
-            /*queryParameters={{ filters: `availableFromMillis <= ${Math.floor(Date.now() / 1000)}` }}*/
+            queryParameters={{ filters: `availableFromMillis <= ${Math.floor(Date.now() / 1000)}` }}
             objectIDs={[data._id]}
             limit={3}
             layoutComponent={({ items }) => {


### PR DESCRIPTION
Ser ut som det her skal filtrere ut fremtidige artikler. Har ikke tilgang til algolia (cc @majatestad), men nå har jeg klikka meg mye rundt i preview og jeg har 1) ikke fått opp artikler frem i tid, 2) fått opp artikler fra i dag og 3) fått anbefalt de 3 samme artiklene (What is functional programming, Vanilla SPA og en til) i 90% av tilfellene 🤷‍♂️