### PR TITLE
Fiks redirect feil

### DIFF
--- a/web/app/routes/category.$tag.tsx
+++ b/web/app/routes/category.$tag.tsx
@@ -1,7 +1,10 @@
 import { LoaderFunctionArgs, redirect } from '@vercel/remix'
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  return redirect(`/kategori/${params.tag}`, {
+  if (!params.tag) {
+    return redirect('/kategori')
+  }
+  return redirect(`/kategori/${encodeURIComponent(params.tag)}`, {
     status: 301,
   })
 }

--- a/web/app/routes/kategori.$tag.tsx
+++ b/web/app/routes/kategori.$tag.tsx
@@ -18,6 +18,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw new Response('Missing tag', { status: 404 })
   }
 
+  const decodedTag = decodeURIComponent(tag)
+
   // Get page from URL search params
   const url = new URL(request.url)
   const page = parseInt(url.searchParams.get('page') || '1')
@@ -25,7 +27,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const offset = (page - 1) * perPage
 
   const response = await loadQuery<TAG_WITH_POSTS_QUERYResult>(TAG_WITH_POSTS_QUERY, {
-    t: tag,
+    t: decodedTag,
     start: offset,
     end: offset + perPage,
   })

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -92,9 +92,11 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     return redirect(`/post/${year}/${date.padStart(2, '0')}/${encodeURIComponent(slug)}`, { status: 301 })
   }
 
+  const decodedSlug = decodeURIComponent(slug)
+
   const { options, preview } = await loadQueryOptions(request.headers)
 
-  const initial = await loadQuery<POST_BY_SLUGResult>(POST_BY_SLUG, { slug }, options)
+  const initial = await loadQuery<POST_BY_SLUGResult>(POST_BY_SLUG, { slug: decodedSlug }, options)
 
   const formatDate = year + '-' + '12' + '-' + date.padStart(2, '0')
   const currentDate = new Date(new Date().getTime() + 1000 * 60 * 60)

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -21,8 +21,8 @@ import { useRef } from 'react'
 import { DoorSign } from '~/components/DoorSign'
 import { Article } from '~/features/article/Article'
 import { RelatedPostsLayout } from '~/features/article/RelatedPostLayout'
-import Header from '~/features/header/Header'
 import Series, { shouldShowSeries } from '~/features/article/Series'
+import Header from '~/features/header/Header'
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   const post = data?.initial.data
@@ -89,7 +89,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { year, date, slug } = parsedParams.data
 
   if (date.length === 1) {
-    return redirect(`/post/${year}/${date.padStart(2, '0')}/${slug}`, { status: 301 })
+    return redirect(`/post/${year}/${date.padStart(2, '0')}/${encodeURIComponent(slug)}`, { status: 301 })
   }
 
   const { options, preview } = await loadQueryOptions(request.headers)


### PR DESCRIPTION
## Beskrivelse
Når man prøver å redirecte til en side med æ, ø eller å i navnet, så feiler Vercel, siden det ikke er lov å sende ikke-ascii bokstaver som headers.

Når man redirecter får man tilbake en 301 eller 302 HTTP status-kode, med en `Location` header, som inneholder hvor man skal bli videresendt til. Det er altså denne som ikke kan inneholde æ-er, ø-er eller å-er. 

#️⃣ Punktliste av hva som er endret:
- Wrap slugs og kategorinavn med "encodeURIComponent", som gjør om æøå til litt mer URL-vennlige strings.
- Når man henter ut slugs og kategorinavn, husk å kalle den motsatte "decodeURIComponent" funksjonen for å få tilbake spesialtegnene.