### PR TITLE
Legg til HCL som støttet språk og støtt uppercase-språk

### DIFF
--- a/web/app/portable-text/CodeBlock.tsx
+++ b/web/app/portable-text/CodeBlock.tsx
@@ -13,6 +13,7 @@ import gradle from 'refractor/lang/gradle.js'
 import graphql from 'refractor/lang/graphql.js'
 import groovy from 'refractor/lang/groovy.js'
 import haskell from 'refractor/lang/haskell.js'
+import hcl from 'refractor/lang/hcl.js'
 import idris from 'refractor/lang/idris.js'
 import java from 'refractor/lang/java.js'
 import json from 'refractor/lang/json.js'
@@ -70,7 +71,7 @@ registerLanguage(csv)
 registerLanguage(elixir)
 registerLanguage(idris)
 registerLanguage(glsl)
-
+registerLanguage(hcl)
 interface CodeBlockProps {
   code: CodeType
 }
@@ -78,7 +79,8 @@ export const CodeBlock = ({ code }: CodeBlockProps) => {
   if (!code?.code) {
     return null
   }
-  const language = nonSupportedLanguages.includes(code.language ?? '') ? 'text' : (code.language ?? 'text')
+  let language = nonSupportedLanguages.includes(code.language ?? '') ? 'text' : (code.language ?? 'text')
+  language = language.toLowerCase()
   return (
     <div className="codeBlockColorOverride text-sm max-w-[800px] overflow-hidden rounded-md">
       <div className="overflow-x-auto bg-gray-50 p-4">
@@ -92,16 +94,4 @@ export const CodeBlock = ({ code }: CodeBlockProps) => {
  * but that are in the Sanity database somehow.
  * In a perfect world, we should remove them from the database.
  **/
-const nonSupportedLanguages = [
-  'jsonnet',
-  'F#',
-  'Kotlin',
-  'example',
-  'TSX',
-  'math',
-  'jsonc',
-  'CSS',
-  'svelte',
-  'HCL',
-  'JavaScript',
-]
+const nonSupportedLanguages = ['jsonnet', 'F#', 'example', 'math', 'jsonc', 'svelte']


### PR DESCRIPTION
## Beskrivelse

Språket "hcl" var ikke lagt til som et gyldig språk for refractor (kodehighlighteren vår), så da kræsjer https://www.bekk.christmas/post/2019/20/terraforming-christmas-cards. Ikkje bra.

Heldigvis støtter refractor hcl!

I tillegg så så jeg at vi egentlig støtter flere av de språkene som er lagt til på "ikke-støtta"-listen jeg laget i forrige PR – bare at de er skrevet med feil casing. Denne PRen tar derfor og endrer språket til lowercase-versjonen av hva enn vi får inn. Dette gjør at et par flere artikler får den kodehighlighten vi ønsker.

#️⃣ Punktliste av hva som er endret:

- Legg til støtte for hcl
- Lowercase alle språk vi får inn, så vi kan highlighte kode i et par flere innholdsartikler.

Du kan se at siden ikke kræsjer lenger her: https://bekk-blogg-git-registrer-hcl-som-sprk-bekk.vercel.app/post/2019/20/terraforming-christmas-cards