### PR TITLE
Vis en enklere versjon av URLen om opengraph.ninja feiler

### DIFF
--- a/web/app/components/RelatedLink.tsx
+++ b/web/app/components/RelatedLink.tsx
@@ -10,19 +10,15 @@ type RelatedLinkElementProps = {
 export const RelatedLinkElement = ({ link, language }: RelatedLinkElementProps) => {
   const previewData = usePreviewData(link.url)
 
-  if (previewData.status !== 'success') {
+  if (previewData.status === 'loading') {
     const loadingText = language === 'en-US' ? 'Loading…' : 'Laster…'
-    const errorText =
-      language === 'en-US'
-        ? 'Woops. An error has occured, and we are not able to find the link!'
-        : 'Uffda. En feil har oppstått, og vi klarer ikke å hente lenken!'
 
     return (
       <div
         key={link._key}
         className="flex items-center pl-4 mt-4 bg-light-gray rounded-xl h-full max-h-20 min-h-20 sm:max-h-28 sm:min-h-28 hover:underline hover:shadow-md transition-shadow group"
       >
-        <p> {previewData.status === 'loading' ? loadingText : errorText} </p>
+        <p>{loadingText}</p>
       </div>
     )
   }
@@ -33,6 +29,14 @@ export const RelatedLinkElement = ({ link, language }: RelatedLinkElementProps) 
 
   const url = new URL(link.url)
 
+  const title = link.title ?? (previewData.status === 'success' ? previewData.data.title : link.url)
+  const description =
+    link.description ??
+    (previewData.status === 'success'
+      ? (previewData.data?.description ?? previewData.data?.details['ogTitle'] ?? url.hostname)
+      : url.hostname)
+  const image = previewData.status === 'success' ? (previewData.data?.image?.url ?? `${url.origin}/favicon.ico`) : null
+
   return (
     <div
       key={link._key}
@@ -40,21 +44,11 @@ export const RelatedLinkElement = ({ link, language }: RelatedLinkElementProps) 
     >
       <Link to={link.url} className="flex w-full">
         <div className="flex flex-grow flex-col justify-center ml-5 w-[125px] no-underline">
-          <h3 className="line-clamp-2 sm:line-clamp-2 text-base mb-1 sm:text-xl">
-            {link.title ?? previewData.data.title}
-          </h3>
-          <p className="line-clamp-1 sm:line-clamp-2 text-sm">
-            {link.description ?? previewData.data.description ?? previewData.data.details['ogTitle']}
-          </p>
+          <h3 className="line-clamp-2 sm:line-clamp-2 text-base mb-1 sm:text-xl">{title}</h3>
+          <p className="line-clamp-1 sm:line-clamp-2 text-sm">{description}</p>
         </div>
         <div className="flex flex-col justify-center items-center ml-2 max-sm:w-[0px] sm:w-[150px] md:w-[0px] xl:w-[150px] sm:ml-14 sm:mr-4 sm:m-2">
-          {previewData.data.image && (
-            <img
-              src={previewData.data.image.url ?? `${url.origin}/favicon.ico`}
-              alt={''}
-              className="rounded-xl overflow-hidden"
-            />
-          )}
+          {image && <img src={image} alt={''} className="rounded-xl overflow-hidden" />}
         </div>
         <div className="sm:hidden md:flex md:items-center xl:hidden flex ml-auto items-center mr-4 sm:mr-4 sm:mb-4">
           <svg


### PR DESCRIPTION
## Beskrivelse

Medium har begynt å blokkere URL-previewen vår – opengraph.ninja (laget av undertegnede) – fra å hente previews av artikler. Det er jo ikke helt prima.

Det som er litt kjipt er at i de tilfellene, så viser vi aldri lenken – vi viser bare at det ikke fungerte! Så det denne PRen gjør er å vise frem det vi vet fra URLen, og beholde lenken – bare uten fancy preview.