### PR TITLE
Fiks noen søkebugs

### DIFF
--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -1,18 +1,15 @@
 import { Link } from '@remix-run/react'
-import { SearchClient } from 'algoliasearch'
 import { Configure, Hits, InstantSearch, useSearchBox } from 'react-instantsearch'
+import { useAlgoliaClient, useAlgoliaConfig } from '~/hooks/useAlgolia'
 import { postUrl } from '~/lib/format'
-export const Search = ({
-  searchClient,
-  indexName,
-}: {
-  searchClient: React.MutableRefObject<SearchClient>
-  indexName: string
-}) => {
+
+export const Search = () => {
+  const algoliaConfig = useAlgoliaConfig()
+  const client = useAlgoliaClient()
   return (
     <InstantSearch
-      searchClient={searchClient.current}
-      indexName={indexName}
+      searchClient={client.current}
+      indexName={algoliaConfig.index}
       future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
     >
       <SearchBoxWithDropdown />

--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@remix-run/react'
-import { Configure, Hits, InstantSearch, useSearchBox } from 'react-instantsearch'
+import { Configure, Hits, InstantSearch, InstantSearchSSRProvider, useSearchBox } from 'react-instantsearch'
 import { useAlgoliaClient, useAlgoliaConfig } from '~/hooks/useAlgolia'
 import { postUrl } from '~/lib/format'
 
@@ -7,35 +7,16 @@ export const Search = () => {
   const algoliaConfig = useAlgoliaConfig()
   const client = useAlgoliaClient()
   return (
-    <InstantSearch
-      searchClient={client.current}
-      indexName={algoliaConfig.index}
-      future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
-    >
-      <SearchBoxWithDropdown />
-      <Configure hitsPerPage={5} />
-    </InstantSearch>
-  )
-}
-
-function CustomSearchBox({
-  query,
-  refine,
-  clear,
-}: {
-  query: string
-  refine: (value: string) => void
-  clear: () => void
-}) {
-  return (
-    <input
-      type="search"
-      value={query}
-      onChange={(event) => refine(event.currentTarget.value)}
-      placeholder="Søk"
-      onReset={clear}
-      className="w-full max-w-lg h-12 px-4 py-2 text-lg bg-transparent rounded-sm border border-white focus:outline-none focus:ring-2 focus:ring-white focus:text-white placeholder-white"
-    />
+    <InstantSearchSSRProvider>
+      <InstantSearch
+        searchClient={client.current}
+        indexName={algoliaConfig.index}
+        future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
+      >
+        <SearchBoxWithDropdown />
+        <Configure hitsPerPage={5} />
+      </InstantSearch>
+    </InstantSearchSSRProvider>
   )
 }
 
@@ -51,6 +32,33 @@ const SearchBoxWithDropdown = () => {
         </div>
       )}
     </div>
+  )
+}
+
+function CustomSearchBox({
+  query,
+  refine,
+  clear,
+}: {
+  query: string
+  refine: (value: string) => void
+  clear: () => void
+}) {
+  return (
+    <>
+      <label htmlFor="search" className="sr-only">
+        Søk
+      </label>
+      <input
+        id="search"
+        type="search"
+        value={query}
+        onChange={(event) => refine(event.currentTarget.value)}
+        placeholder="Søk"
+        onReset={clear}
+        className="w-full max-w-lg h-12 px-4 py-2 text-lg bg-transparent rounded-sm border border-white focus:outline-none focus:ring-2 focus:ring-white focus:text-white placeholder-white"
+      />
+    </>
   )
 }
 

--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -1,5 +1,5 @@
-import { SearchClient } from 'algoliasearch'
 import { Link } from '@remix-run/react'
+import { SearchClient } from 'algoliasearch'
 import { Configure, Hits, InstantSearch, useSearchBox } from 'react-instantsearch'
 import { postUrl } from '~/lib/format'
 export const Search = ({
@@ -10,7 +10,11 @@ export const Search = ({
   indexName: string
 }) => {
   return (
-    <InstantSearch searchClient={searchClient.current} indexName={indexName}>
+    <InstantSearch
+      searchClient={searchClient.current}
+      indexName={indexName}
+      future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
+    >
       <SearchBoxWithDropdown />
       <Configure hitsPerPage={5} />
     </InstantSearch>

--- a/web/app/features/article/RelatedPostLayout.tsx
+++ b/web/app/features/article/RelatedPostLayout.tsx
@@ -1,8 +1,8 @@
 import { Link } from '@remix-run/react'
 import { motion } from 'framer-motion'
 
-import { parseDate } from '../../../utils/date'
 import { trackEvent } from '../../../utils/analytics'
+import { parseDate } from '../../../utils/date'
 
 interface RelatedPostsData {
   objectID: string
@@ -46,7 +46,9 @@ export const RelatedPostsLayout = ({ items }: { items: RelatedPostsData[] }) => 
             >
               <div className="">
                 <h3 className="text-lg font-semibold mt-2">{item.name}</h3>
-                <p className="text-sm">{item.author}</p>
+                <p className="text-sm">
+                  {new Intl.ListFormat('nb-NO', { type: 'conjunction', style: 'long' }).format(item.author)}
+                </p>
                 <p className="text-sm text-gray-500">
                   {date.day}. desember, {date.year}
                 </p>

--- a/web/app/features/header/Header.tsx
+++ b/web/app/features/header/Header.tsx
@@ -1,26 +1,17 @@
-import { Link, useMatches, useParams, useRouteError } from '@remix-run/react'
+import { Link, useParams, useRouteError } from '@remix-run/react'
 
 import { PostStamp } from '../article/PostStamp'
 
+import { Search } from '~/components/Search'
 import { BekkLogo } from '~/features/article/BekkLogo'
 import { useBreadcrumbs } from '~/hooks/useBreadcrumbs'
-import algoliasearch from 'algoliasearch'
-import { Search } from '~/components/Search'
-import { useRef } from 'react'
-
-const useAlgoliaConfig = () => {
-  const rootMatch = useMatches().find((match) => match.id === 'root')
-  return (rootMatch?.data as { algolia: { app: string; key: string; index: string } })?.algolia
-}
 
 export const Header = () => {
-  const algolia = useAlgoliaConfig()
   const breadcrumbs = useBreadcrumbs()
   const error = useRouteError()
   const { year, date, slug } = useParams()
   const isOnArticlePage = Boolean(year && date && slug)
-  const searchClient = useRef(algolia && algoliasearch(algolia.app, algolia.key))
-  const showSearch = algolia && searchClient && !isOnArticlePage && !error
+  const showSearch = !isOnArticlePage && !error
 
   return (
     <div
@@ -41,7 +32,7 @@ export const Header = () => {
       </div>
       {showSearch && (
         <div className="md:col-start-1 md:col-span-2 md:row-start-1 flex justify-start md:justify-center order-first md:order-none  md:mx-auto">
-          <Search searchClient={searchClient} indexName={algolia.index} />
+          <Search />
         </div>
       )}
       {!error && (

--- a/web/app/hooks/useAlgolia.ts
+++ b/web/app/hooks/useAlgolia.ts
@@ -1,0 +1,14 @@
+import { useMatches } from '@remix-run/react'
+import algoliasearch from 'algoliasearch'
+import { useRef } from 'react'
+
+export const useAlgoliaConfig = () => {
+  const rootMatch = useMatches().find((match) => match.id === 'root')
+  return (rootMatch?.data as { algolia: { app: string; key: string; index: string } })?.algolia
+}
+
+export const useAlgoliaClient = () => {
+  const config = useAlgoliaConfig()
+  const client = useRef(algoliasearch(config.app, config.key))
+  return client
+}

--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -15,7 +15,6 @@ import { SpeedInsights } from '@vercel/speed-insights/remix'
 import { lazy, Suspense } from 'react'
 import { loadQueryOptions } from 'utils/sanity/loadQueryOptions.server'
 import { generateSecurityHeaders } from 'utils/security'
-
 import { ErrorPage } from './features/error-boundary/ErrorPage'
 import { JumpToContent } from './features/jump-to-content/JumpToContent'
 

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -222,7 +222,11 @@ export default function ArticleRoute() {
       </div>
       {shouldShowSeries(data) && data.series && <Series postId={data._id} series={data.series} mobileOnly />}
       <div>
-        <InstantSearch searchClient={searchClient.current} indexName={algolia.index}>
+        <InstantSearch
+          searchClient={searchClient.current}
+          indexName={algolia.index}
+          future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
+        >
           <RelatedProducts
             headerComponent={() => (
               <div className="inset-0 flex m-6 justify-center ">

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -147,11 +147,6 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       query: POST_BY_SLUG,
       params: parsedParams.data,
       imageUrl,
-      algolia: {
-        appId: process.env.ALGOLIA_APP_ID!,
-        apiKey: process.env.ALGOLIA_SEARCH_KEY!,
-        index: process.env.ALGOLIA_INDEX!,
-      },
     },
     {
       status: 200,
@@ -197,7 +192,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 export const headers = combinedHeaders
 
 export default function ArticleRoute() {
-  const { initial, query, params, algolia } = useLoaderData<typeof loader>()
+  const { initial, query, params } = useLoaderData<typeof loader>()
   const { data } = useQuery<typeof initial.data>(query, params, {
     // @ts-expect-error Dette er en kjent bug i sanity-react-loader
     initial,

--- a/web/app/routes/post.$year.$date.$slug.tsx
+++ b/web/app/routes/post.$year.$date.$slug.tsx
@@ -1,7 +1,6 @@
 import { isRouteErrorResponse, json, redirect, useLoaderData, useRouteError } from '@remix-run/react'
 import { useQuery } from '@sanity/react-loader'
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@vercel/remix'
-import algoliasearch from 'algoliasearch/lite'
 import { InstantSearch, RelatedProducts } from 'react-instantsearch'
 import { cleanControlCharacters } from 'utils/controlCharacters'
 import { combinedHeaders } from 'utils/headers'
@@ -17,12 +16,12 @@ import { ErrorPage } from '../features/error-boundary/ErrorPage'
 
 import '../portable-text/prism-theme.css'
 
-import { useRef } from 'react'
 import { DoorSign } from '~/components/DoorSign'
 import { Article } from '~/features/article/Article'
 import { RelatedPostsLayout } from '~/features/article/RelatedPostLayout'
 import Series, { shouldShowSeries } from '~/features/article/Series'
 import Header from '~/features/header/Header'
+import { useAlgoliaClient, useAlgoliaConfig } from '~/hooks/useAlgolia'
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   const post = data?.initial.data
@@ -203,7 +202,8 @@ export default function ArticleRoute() {
     // @ts-expect-error Dette er en kjent bug i sanity-react-loader
     initial,
   })
-  const searchClient = useRef(algoliasearch(algolia.appId, algolia.apiKey))
+  const algoliaConfig = useAlgoliaConfig()
+  const client = useAlgoliaClient()
 
   if (!data) {
     return null
@@ -223,14 +223,14 @@ export default function ArticleRoute() {
       {shouldShowSeries(data) && data.series && <Series postId={data._id} series={data.series} mobileOnly />}
       <div>
         <InstantSearch
-          searchClient={searchClient.current}
-          indexName={algolia.index}
+          searchClient={client.current}
+          indexName={algoliaConfig.index}
           future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
         >
           <RelatedProducts
             headerComponent={() => (
               <div className="inset-0 flex m-6 justify-center ">
-                <DoorSign>Relaterte artikler</DoorSign>
+                <DoorSign>Relatert innhold</DoorSign>
               </div>
             )}
             objectIDs={[data._id]}

--- a/web/utils/security.ts
+++ b/web/utils/security.ts
@@ -39,6 +39,7 @@ export function generateSecurityHeaders() {
         '*.algolia.net',
         'ws-us3.pusher.com',
         '*.algolia.io',
+        '*.algolianet.com',
       ],
       'frame-src': [
         SELF,
@@ -75,7 +76,6 @@ export function generateSecurityHeaders() {
       'microphone=()',
       'payment=()',
       'usb=()',
-      'interest-cohort=()',
     ].join(', '),
     'X-XSS-Protection': '1; mode=block',
   }


### PR DESCRIPTION
## Beskrivelse

Gikk gjennom søkeimplementasjonen, og rettet opp noen greier her og der.

#️⃣ Punktliste av hva som er endret:
- La til noen manglende domener i CSPen vår
- Fiksa noen console-feil
- La til noen future flags for instant search APIet, så det ikke klager under utvikling
- Laget to hooks – useAlgoliaConfig og useAlgoliaClient – og brukte dem rundt om der det var behov
- Fikset en bug med formatteringen av forfattere på relatert innhold
- Endret overskriften på relatert innhold fra "Relaterte artikler" til "Relatert innhold"