### PR TITLE
Optimaliser bilder med srcset

### DIFF
--- a/web/app/features/article/Article.tsx
+++ b/web/app/features/article/Article.tsx
@@ -115,21 +115,35 @@ export const Article = ({ post }: ArticleProps) => {
         )}
         {post.coverImage && !post.coverImage.hideFromPost && (
           <div className="mb-7">
-            <img
-              src={
-                post.coverImage.asset
-                  ? urlFor(post.coverImage.asset as unknown as SanityImageAsset)
-                      .width(1700)
+            {post.coverImage.asset ? (
+              <img
+                src={urlFor(post.coverImage.asset as SanityImageAsset)
+                  .width(1700)
+                  .quality(80)
+                  .url()}
+                srcSet={[400, 800, 1200, 1700]
+                  .map((width) => {
+                    const url = urlFor(post.coverImage!.asset as SanityImageAsset)
+                      .width(width)
                       .quality(80)
                       .url()
-                  : (post.coverImage.src ?? '')
-              }
-              alt={post.coverImage.alt || ''}
-              className="w-full rounded-2xl object-cover max-w-full"
-              style={{
-                aspectRatio: post.coverImage.asset?.metadata?.dimensions?.aspectRatio ?? undefined,
-              }}
-            />
+                    return `${url} ${width}w`
+                  })
+                  .join(', ')}
+                sizes="(max-width: 400px) 400px, (max-width: 800px) 800px, (max-width: 1200px) 1200px, 1700px"
+                alt={post.coverImage.alt || ''}
+                className="w-full rounded-2xl object-cover max-w-full"
+                style={{
+                  aspectRatio: post.coverImage.asset?.metadata?.dimensions?.aspectRatio ?? undefined,
+                }}
+              />
+            ) : (
+              <img
+                src={post.coverImage.src ?? ''}
+                alt={post.coverImage.alt || ''}
+                className="w-full rounded-2xl object-cover max-w-full"
+              />
+            )}
           </div>
         )}
         {post.content && (

--- a/web/app/portable-text/ImageBlock.tsx
+++ b/web/app/portable-text/ImageBlock.tsx
@@ -1,3 +1,4 @@
+import { SanityImageSource } from '@sanity/image-url/lib/types/types'
 import type { ImageWithMetadata, SanityImageAsset } from '../../utils/sanity/types/sanity.types'
 import { urlFor } from '../../utils/sanity/utils'
 
@@ -9,36 +10,71 @@ export default function ImageBlock({ image }: ImageWithMetadataDisplayProps) {
   if (!image) {
     return null
   }
-  const imageUrl = image.asset ? urlFor(image.asset).width(1700).quality(80).url() : image.src
-  const asset = image.asset as unknown as SanityImageAsset
-  const metadata = asset?.metadata
 
-  const aspectRatio = metadata?.dimensions?.aspectRatio
-
-  if (!imageUrl) {
-    return null
+  // If we have a direct src URL, use it without srcset
+  if (!image.asset && image.src) {
+    return (
+      <figure style={{ maxWidth: image.maxWidth || '100%' }}>
+        <img
+          src={image.src}
+          alt={image.alt || ''}
+          style={{
+            width: '100%',
+            objectFit: 'cover',
+            borderRadius: '20px',
+          }}
+        />
+        {renderCaption(image)}
+      </figure>
+    )
   }
 
+  // For Sanity assets, create responsive srcset
+  if (image.asset) {
+    const asset = image.asset as unknown as SanityImageAsset
+    const metadata = asset?.metadata
+    const aspectRatio = metadata?.dimensions?.aspectRatio
+
+    const imageSizes = [400, 800, 1200, 1700]
+    const srcSet = imageSizes
+      .map((width) => {
+        const url = urlFor(image.asset as SanityImageSource)
+          .width(width)
+          .quality(80)
+          .url()
+        return `${url} ${width}w`
+      })
+      .join(', ')
+
+    return (
+      <figure style={{ maxWidth: image.maxWidth || '100%', aspectRatio }}>
+        <img
+          src={urlFor(image.asset).width(1700).quality(80).url()}
+          srcSet={srcSet}
+          sizes="(max-width: 400px) 400px, (max-width: 800px) 800px, (max-width: 1200px) 1200px, 1700px"
+          alt={image.alt || ''}
+          style={{
+            width: '100%',
+            objectFit: 'cover',
+            borderRadius: '20px',
+            aspectRatio: aspectRatio,
+          }}
+        />
+        {renderCaption(image)}
+      </figure>
+    )
+  }
+
+  return null
+}
+
+function renderCaption(image: ImageWithMetadata) {
+  if (!image.caption) return null
+
   return (
-    <figure style={{ maxWidth: image.maxWidth || '100%', aspectRatio }}>
-      <img
-        src={imageUrl}
-        alt={image.alt || ''}
-        style={{
-          width: '100%',
-          objectFit: 'cover',
-          borderRadius: '20px',
-          aspectRatio: aspectRatio,
-        }}
-      />
-      {image.caption && (
-        <figcaption className="pt-1.5 md:pt-3 text-gray-700 text-xs md:text-sm">
-          {(image.caption ? image.caption : '') +
-            (image.src && !image.caption?.includes(image.src)
-              ? ` ${image.caption ? '|' : ''} Kilde: ${image.src}`
-              : '')}
-        </figcaption>
-      )}
-    </figure>
+    <figcaption className="pt-1.5 md:pt-3 text-gray-700 text-xs md:text-sm">
+      {(image.caption ? image.caption : '') +
+        (image.src && !image.caption?.includes(image.src) ? ` ${image.caption ? '|' : ''} Kilde: ${image.src}` : '')}
+    </figcaption>
   )
 }


### PR DESCRIPTION
## Beskrivelse

I dag så viser vi det samme bildet uansett hva slags enhet du har. Men takket være `srcset` attributten til bilder, så kan man faktisk gi forskjellige bilder basert på hvilken størrelse devicen din har!

Denne PRen (automagisk generert av AI) legger til forskjellige størrelser på bildene, slik at man ikke laster ned mer enn man trenger.

Test gjerne at bilder ser bra ut – både cover image, men også bilder i artikler.