### PR TITLE
Søkefelt på kalendersiden (kun desktop)

### DIFF
--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -6,6 +6,7 @@ import { postUrl } from '~/lib/format'
 export const Search = () => {
   const algoliaConfig = useAlgoliaConfig()
   const client = useAlgoliaClient()
+
   return (
     <InstantSearchSSRProvider>
       <InstantSearch
@@ -14,7 +15,7 @@ export const Search = () => {
         future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
       >
         <SearchBoxWithDropdown />
-        <Configure hitsPerPage={5} />
+        <Configure hitsPerPage={5} filters={`availableFromMillis <=  ${Date.now()}`} />
       </InstantSearch>
     </InstantSearchSSRProvider>
   )
@@ -27,7 +28,7 @@ const SearchBoxWithDropdown = () => {
     <div className="relative w-[75%] md:w-[500px]">
       <CustomSearchBox query={query} refine={refine} clear={clear} />
       {query && (
-        <div className="absolute z-10 mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300">
+        <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300">
           <Hits hitComponent={Hit} />
         </div>
       )}
@@ -82,9 +83,9 @@ const Hit = ({
   const tags = hit.tags && hit.tags.length > 0 ? formatter.format(hit.tags) : null
 
   return (
-    <div className="px-4 py-2 border-b border-black ">
-      <Link to={link} className="text-black hover:text-reindeer-brown">
-        <div className="font-semibold text-base">{title}</div>
+    <div className="px-4 py-2 border-b hover:bg-gray-300 rounded-sm">
+      <Link to={link}>
+        <div className="text-base text-black">{title}</div>
         <div className="text-sm text-gray-600">
           {authors && <span>{authors}</span>}
           {tags && (

--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -15,7 +15,7 @@ export const Search = () => {
         future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
       >
         <SearchBoxWithDropdown />
-        <Configure hitsPerPage={5} filters={`availableFromMillis <=  ${Date.now()}`} />
+        <Configure hitsPerPage={20} filters={`availableFromMillis <=  ${Date.now()}`} />
       </InstantSearch>
     </InstantSearchSSRProvider>
   )
@@ -28,7 +28,7 @@ const SearchBoxWithDropdown = () => {
     <div className="relative w-[75%] md:w-[500px]">
       <CustomSearchBox query={query} refine={refine} clear={clear} />
       {query && (
-        <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300">
+        <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300 max-h-[290px] overflow-y-scroll">
           <Hits hitComponent={Hit} />
         </div>
       )}

--- a/web/app/features/calendar/CalendarWithDoors.tsx
+++ b/web/app/features/calendar/CalendarWithDoors.tsx
@@ -1,5 +1,6 @@
 import { useLoaderData } from '@remix-run/react'
 import { motion } from 'framer-motion'
+import { Search } from '~/components/Search'
 
 import { Door } from '~/features/calendar/Door'
 import { Gift2SVG } from '~/features/calendar/giftsSVG/Gift2SVG'
@@ -10,10 +11,13 @@ export const CalendarWithDoors = () => {
   return (
     <div className="sm:px-4 grid grid-cols-[25px_auto_25px] sm:grid-cols-[50px_auto_50px] 2lg:grid-cols-[auto_auto_auto] grid-rows-[91px_auto] sm:grid-rows-[142px_auto] md:grid-rows-[179px_auto] 2lg:grid-rows-[292px_auto]">
       {/* Roof */}
-      <div className="bg-roof row-start-1 row-span-2 col-start-1 col-span-3 z-5">
-        <h1 className="text-postcard-beige font-delicious text-center text-2xl sm:text-4xl md:text-5xl mt-[45px] sm:mt-[80px] md:mt-[110px] 2lg:mt-[180px] 2lg:pr-5">
+      <div className="bg-roof row-start-1 row-span-2 col-start-1 col-span-3 z-5 flex flex-col items-center">
+        <h1 className="text-postcard-beige font-delicious text-center text-2xl sm:text-4xl md:text-5xl mt-[45px] sm:mt-[80px] md:mt-[110px] 2lg:mt-[160px] 2lg:pr-5 mb-4">
           {data.year}
         </h1>
+        <div className="text-white hidden 2lg:block">
+          <Search />
+        </div>
       </div>
       {/* Gift left */}
       <div className="row-start-2 row-span-1 col-start-1 col-span-1 hidden 2lg:flex self-end">

--- a/web/app/features/header/Header.tsx
+++ b/web/app/features/header/Header.tsx
@@ -31,7 +31,7 @@ export const Header = () => {
         </Link>
       </div>
       {showSearch && (
-        <div className="md:col-start-1 md:col-span-2 md:row-start-1 flex justify-start md:justify-center order-first md:order-none  md:mx-auto">
+        <div className="md:col-start-1 md:col-span-2 md:row-start-1 flex justify-start md:justify-center order-first md:order-none md:mx-auto text-white">
           <Search />
         </div>
       )}


### PR DESCRIPTION
## Beskrivelse

På søkefeltkomponenten
- Filtrerer ut søketreff som er frem i tid, for å unngå 404
- Økt z-index for å vise søkeresultatet over kalendersiden, og litt styling på borders og hovereffekt

På kalendersiden:
- Lagt til søkefeltet på skjermer > 1130px. For skjermer under den størrelsen skal det vises i headeren. Det fikser jeg i egen PR.

## Bilder

Søkefelt på kalendersiden
![image](https://github.com/user-attachments/assets/e155606e-cbc4-4b85-ac06-09433ed5a474)
![image](https://github.com/user-attachments/assets/b974ce0f-68ca-4cee-948f-a62d4d3f6447)


Hover-effekt: 
![image](https://github.com/user-attachments/assets/790252c3-ef68-43b6-8169-55791e9aee9e)
