### PR TITLE
Gjør om figure i ImageBlock til en inline-block

### DIFF
--- a/web/app/portable-text/ImageBlock.tsx
+++ b/web/app/portable-text/ImageBlock.tsx
@@ -47,7 +47,7 @@ export default function ImageBlock({ image }: ImageWithMetadataDisplayProps) {
       .join(', ')
 
     return (
-      <figure style={{ maxWidth: image.maxWidth || '100%', aspectRatio }}>
+      <figure style={{ maxWidth: image.maxWidth || '100%', aspectRatio, display: 'inline-block' }}>
         <img
           src={urlFor(image.asset).width(1700).quality(80).url()}
           srcSet={srcSet}


### PR DESCRIPTION
Fikser en bug i safari hvor tekst under en ImageBlock fløt over i bilde-caption

Før: 
![image](https://github.com/user-attachments/assets/52a8cab2-1d49-44b0-aa90-aa45df3f87d3)

Etter:
![image](https://github.com/user-attachments/assets/6d19ae3e-e43c-4a9f-9d4c-da38ced29e07)

