### PR TITLE
snow animation covers entire screen

### DIFF
--- a/web/app/features/calendar/SnowAnimation.tsx
+++ b/web/app/features/calendar/SnowAnimation.tsx
@@ -60,7 +60,7 @@ export const SnowAnimation = () => {
   }, [flakes, maxFlakes])
 
   return (
-    <div className="absolute w-full h-full top-0 overflow-hidden pointer-events-none">
+    <div className="fixed inset-0 w-full h-full top-0 overflow-hidden pointer-events-none min-h-screen z-20">
       {flakes.map((flake) => (
         <Snowflake key={flake.id} size={flake.size} left={flake.left} duration={flake.duration} />
       ))}

--- a/web/app/features/calendar/SnowAnimation.tsx
+++ b/web/app/features/calendar/SnowAnimation.tsx
@@ -60,7 +60,7 @@ export const SnowAnimation = () => {
   }, [flakes, maxFlakes])
 
   return (
-    <div className="fixed inset-0 w-full h-full top-0 overflow-hidden pointer-events-none min-h-screen z-20">
+    <div className="fixed w-full h-full top-0 overflow-hidden pointer-events-none min-h-screen z-20">
       {flakes.map((flake) => (
         <Snowflake key={flake.id} size={flake.size} left={flake.left} duration={flake.duration} />
       ))}


### PR DESCRIPTION
## Beskrivelse
Snøanimasjonen faller nå helt til bunnen av skjermen på liten skjerm og faller ikke bak blanken på hverken liten eller stor skjerm.

#️⃣ Punktliste av hva som er endret:

- Satte en høyere z-indeks på snøanimasjonen


## Bilder

**Før:**
![image](https://github.com/user-attachments/assets/935ab7f2-15e0-4ebf-bb02-804538af4103)

**Etter:**
![image](https://github.com/user-attachments/assets/6e2573be-7a61-4c06-a946-067902b9b14a)
