### PR TITLE
Legg til søkefelt på kalendersiden på mobil

### DIFF
--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -3,7 +3,11 @@ import { Configure, Hits, InstantSearch, InstantSearchSSRProvider, useSearchBox 
 import { useAlgoliaClient, useAlgoliaConfig } from '~/hooks/useAlgolia'
 import { postUrl } from '~/lib/format'
 
-export const Search = () => {
+type SearchProps = {
+  transparent?: boolean
+}
+
+export const Search = ({ transparent = true }: SearchProps) => {
   const algoliaConfig = useAlgoliaConfig()
   const client = useAlgoliaClient()
 
@@ -14,19 +18,19 @@ export const Search = () => {
         indexName={algoliaConfig.index}
         future={{ persistHierarchicalRootCount: true, preserveSharedStateOnUnmount: true }}
       >
-        <SearchBoxWithDropdown />
+        <SearchBoxWithDropdown transparent={transparent} />
         <Configure hitsPerPage={20} filters={`availableFromMillis <=  ${Date.now()}`} />
       </InstantSearch>
     </InstantSearchSSRProvider>
   )
 }
 
-const SearchBoxWithDropdown = () => {
+const SearchBoxWithDropdown = ({ transparent }: SearchProps) => {
   const { query, refine, clear } = useSearchBox()
 
   return (
     <div className="relative w-[75%] md:w-[500px]">
-      <CustomSearchBox query={query} refine={refine} clear={clear} />
+      <CustomSearchBox query={query} refine={refine} clear={clear} transparent={transparent} />
       {query && (
         <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300 max-h-[290px] overflow-y-scroll">
           <Hits hitComponent={Hit} />
@@ -40,24 +44,26 @@ function CustomSearchBox({
   query,
   refine,
   clear,
+  transparent,
 }: {
   query: string
   refine: (value: string) => void
   clear: () => void
+  transparent?: boolean
 }) {
   return (
     <>
       <label htmlFor="search" className="sr-only">
-        Søk
+        Søk etter en artikkel
       </label>
       <input
         id="search"
         type="search"
         value={query}
         onChange={(event) => refine(event.currentTarget.value)}
-        placeholder="Søk"
+        placeholder="Søk etter en artikkel"
         onReset={clear}
-        className="w-full max-w-lg h-12 px-4 py-2 text-lg bg-transparent rounded-sm border border-white focus:outline-none focus:ring-2 focus:ring-white focus:text-white placeholder-white"
+        className={`w-full max-w-lg h-12 px-4 py-2 text-lg rounded-sm border focus:outline-none focus:ring-2 ${transparent ? 'border-white focus:ring-white focus:text-white placeholder-white bg-transparent' : 'border-black focus:ring-black focus:text-black placeholder-black bg-white'}`}
       />
     </>
   )

--- a/web/app/routes/post.$year.tsx
+++ b/web/app/routes/post.$year.tsx
@@ -1,6 +1,7 @@
 import { isRouteErrorResponse, Link, useRouteError } from '@remix-run/react'
 import type { LoaderFunctionArgs, MetaFunction } from '@vercel/remix'
 import { z } from 'zod'
+import { Search } from '~/components/Search'
 
 import { BekkLogo } from '~/features/article/BekkLogo'
 import { BottomPlank } from '~/features/calendar/BottomPlank'
@@ -72,13 +73,15 @@ export const meta: MetaFunction = ({ data }) => {
 export default function YearRoute() {
   return (
     <div className="bg-brick-wall">
+      <div className="pl-6 pt-8 mb-12 2lg:hidden">
+        <Search transparent={false} />
+      </div>
       <div className="2lg:h-auto flex flex-col justify-end items-center min-h-screen">
         <SnowAnimation />
         <Link to="/post/2024" className="absolute top-[20px] md:top-[40px] right-[20px] md:right-[40px]">
           <BekkLogo className="h-auto w-10 md:auto md:w-16" />
         </Link>
         <CalendarWithDoors />
-        {/* Bottom plank*/}
         <BottomPlank />
       </div>
     </div>

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -7,17 +7,13 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
-  timeout: 30_000,
+  timeout: 60_000,
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
   },
 
   projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  timeout: 30_000,
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',

--- a/web/tests/home.spec.ts
+++ b/web/tests/home.spec.ts
@@ -22,7 +22,7 @@ test('navigating all the way to a post in 2024 works as expected', async ({ page
   await expect(page.getByText('Velkommen til en helt ny julefeiring')).toBeVisible()
   await page.getByText('Velkommen til en helt ny julefeiring').click()
 
-  await expect(page).toHaveURL('/post/2024/01/velkommen-til-en-helt-ny-julefeiring', { timeout: 30_000 })
+  await expect(page).toHaveURL('/post/2024/01/velkommen-til-en-helt-ny-julefeiring', { timeout: 60_000 })
   await expect(page).toHaveTitle('Velkommen til en helt ny julefeiring | Bekk Christmas')
   await expect(page.getByRole('heading', { name: 'Velkommen til en helt ny julefeiring', level: 1 })).toBeVisible()
 })

--- a/web/tests/home.spec.ts
+++ b/web/tests/home.spec.ts
@@ -22,7 +22,7 @@ test('navigating all the way to a post in 2024 works as expected', async ({ page
   await expect(page.getByText('Velkommen til en helt ny julefeiring')).toBeVisible()
   await page.getByText('Velkommen til en helt ny julefeiring').click()
 
-  await expect(page).toHaveURL('/post/2024/01/velkommen-til-en-helt-ny-julefeiring')
+  await expect(page).toHaveURL('/post/2024/01/velkommen-til-en-helt-ny-julefeiring', { timeout: 30_000 })
   await expect(page).toHaveTitle('Velkommen til en helt ny julefeiring | Bekk Christmas')
   await expect(page.getByRole('heading', { name: 'Velkommen til en helt ny julefeiring', level: 1 })).toBeVisible()
 })


### PR DESCRIPTION
## Beskrivelse
Søkefelt på mobil!

#️⃣ Punktliste av hva som er endret:
- Lagt til en prop på inputfelt som bestemmer om det skal være transparent eller ikke
- På små skjermer (opp til 2lg) viser søkefeltet i toppen, ellers viser det inni "huset"

Ting som burde gjøres, men som jeg ikke tar i denne PRen:
- Forstørrelsesglassikon til høyre inni søkefeltet
- Når man trykker escape eller inputfeltet mister fokus, burde resultatene skjules
- Når man trykker pil ned eller tab burde lenkene highlightes og kunne velges med enter

## Bilder
![image](https://github.com/user-attachments/assets/eadfdc93-bcf3-4122-a5c0-7988f3984926)


![image](https://github.com/user-attachments/assets/28d09a7c-160b-4633-828e-3f4857125ac3)
