### PR TITLE
Legg til event listeners for escape press og klikk utenfor søkeresultat

### DIFF
--- a/web/app/components/Search.tsx
+++ b/web/app/components/Search.tsx
@@ -65,7 +65,7 @@ const SearchBoxWithDropdown = ({ transparent }: SearchProps) => {
         transparent={transparent}
       />
       {query && showResults && (
-        <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg border border-gray-300 max-h-[290px] overflow-y-scroll">
+        <div className="absolute z-[100] mt-2 w-full bg-white bg-opacity-90 shadow-lg rounded-lg  max-h-[290px] overflow-y-scroll">
           <Hits hitComponent={Hit} />
         </div>
       )}


### PR DESCRIPTION
## Beskrivelse
Når man klikker utenfor søkeresultatet, burde resultatet skjules. Spesielt på mobil er dette relevant, for ellers må man viske ut det man har skrevet for å kunne trykke på luke nr. 1. 

Et lite issue her at man må trykke escape to ganger (første gang fjerner man bare focus fra inputfeltet, og andre gang blir trykket registrert). Usikker på hvorfor, men leste på stackoverflow at det var en bug i chromium (som er rart, for jeg bruker jo supreme firefox..)

#️⃣ Punktliste av hva som er endret:

- Lagt til event listeners for mouseDown og keyUp, som setter `showResults` til false og skjuler resultatene
