### PR TITLE
Revalidate screens at midnight

### DIFF
--- a/web/app/hooks/useMidnightRevalidate.ts
+++ b/web/app/hooks/useMidnightRevalidate.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+import { useRevalidator } from 'react-router'
+
+export function useMidnightRevalidate(hasDateOverride: boolean) {
+  const revalidator = useRevalidator()
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    if (hasDateOverride) return
+
+    const schedule = () => {
+      timeoutRef.current = setTimeout(() => {
+        revalidator.revalidate()
+        schedule()
+      }, msUntilNextUtcMidnightWithBuffer(30_000))
+    }
+
+    schedule()
+
+    return () => {
+      if (timeoutRef.current !== undefined) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = undefined
+      }
+    }
+  }, [hasDateOverride, revalidator])
+}
+
+const msUntilNextUtcMidnightWithBuffer = (bufferMs = 30_000) => {
+  const now = new Date()
+  const next = new Date(now)
+  next.setUTCHours(24, 0, 0, 0)
+  return Math.max(0, next.getTime() - now.getTime() + bufferMs)
+}

--- a/web/app/hooks/useScreenPagination.ts
+++ b/web/app/hooks/useScreenPagination.ts
@@ -13,8 +13,8 @@ export function useScreenPagination<T>(
   )
 
   const [currentPage, setCurrentPage] = useState(Math.min(articlePage, totalPages - 1))
-  const timeoutRef = useRef<number | undefined>(undefined)
-  const intervalRef = useRef<number | undefined>(undefined)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const intervalRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   useEffect(() => {
     if (!articleAmount || totalPages <= 1) return
@@ -23,20 +23,20 @@ export function useScreenPagination<T>(
     const nowSeconds = Math.floor(Date.now() / 1000)
     const untilBoundary = intervalSeconds - (nowSeconds % intervalSeconds)
 
-    timeoutRef.current = window.setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setCurrentPage((page) => (page + 1) % totalPages)
-      intervalRef.current = window.setInterval(() => {
+      intervalRef.current = setInterval(() => {
         setCurrentPage((page) => (page + 1) % totalPages)
       }, rotationIntervalMs)
     }, untilBoundary * 1000)
 
     return () => {
       if (timeoutRef.current !== undefined) {
-        window.clearTimeout(timeoutRef.current)
+        clearTimeout(timeoutRef.current)
         timeoutRef.current = undefined
       }
       if (intervalRef.current !== undefined) {
-        window.clearInterval(intervalRef.current)
+        clearInterval(intervalRef.current)
         intervalRef.current = undefined
       }
     }


### PR DESCRIPTION
## Beskrivelse
Vi har problemer med at skjermene ikke oppdaterer datoen/nettleseren på natten selv om de skrur seg av, som fører til at man ser gammel data på dem. Jeg prøver med dette å få til en revalidate midt på natten, slik at datoen og artiklene oppdaterer seg.

#️⃣ Punktliste av hva som er endret:

- Lager en `useMidnightRevalidate` som kun kjører om man ikke har spesifisert en spesifikk dato i URLen
- Forbedrer litt TS-typer på refs
