### PR TITLE
Use random stamp colors for cards on screen

### DIFF
--- a/web/app/features/screen/LandscapeView.tsx
+++ b/web/app/features/screen/LandscapeView.tsx
@@ -3,6 +3,7 @@ import { POSTS_BY_YEAR_AND_DATEResult } from 'utils/sanity/types/sanity.types'
 
 import { PostScreenPreview } from '~/features/post-preview/PostScreenPreview'
 import { getPostUrl, qrColors } from './utils'
+import { stableRandomIndex } from 'utils/random'
 
 export const LandscapeView = (posts: POSTS_BY_YEAR_AND_DATEResult, year: string, date: string, pageKey?: number) => {
   return (
@@ -21,7 +22,10 @@ export const LandscapeView = (posts: POSTS_BY_YEAR_AND_DATEResult, year: string,
               className="h-full flex flex-col"
             >
               <PostScreenPreview
-                qr={{ url: getPostUrl(post, year, date), qrColors: qrColors[index % qrColors.length] }}
+                qr={{
+                  url: getPostUrl(post, year, date),
+                  qrColors: qrColors[stableRandomIndex(post._id, qrColors.length)],
+                }}
                 {...post}
               />
             </motion.div>

--- a/web/app/features/screen/PortraitView.tsx
+++ b/web/app/features/screen/PortraitView.tsx
@@ -7,6 +7,7 @@ import { BekkLogo } from '../article/BekkLogo'
 import { GiftRightSideArticle } from '../article/svgs/GiftRightSideArticle'
 import { GiftsLeftSideArticle } from '../article/svgs/GiftsLeftSideArticle'
 import { getPostUrl, qrColors } from './utils'
+import { stableRandomIndex } from 'utils/random'
 
 export const PortraitView = (posts: POSTS_BY_YEAR_AND_DATEResult, year: string, date: string, pageKey?: number) => {
   return (
@@ -35,7 +36,10 @@ export const PortraitView = (posts: POSTS_BY_YEAR_AND_DATEResult, year: string, 
                 className="w-full flex flex-row justify-center"
               >
                 <PostScreenPreview
-                  qr={{ url: getPostUrl(post, year, date), qrColors: qrColors[index % qrColors.length] }}
+                  qr={{
+                    url: getPostUrl(post, year, date),
+                    qrColors: qrColors[stableRandomIndex(post._id, qrColors.length)],
+                  }}
                   {...post}
                 />
               </motion.div>

--- a/web/utils/random.ts
+++ b/web/utils/random.ts
@@ -1,0 +1,12 @@
+export const stableRandomIndex = (seed: string, modulo: number) => {
+  if (modulo <= 0) return 0
+
+  // Simple deterministic hash (FNV-1a-ish) to get a stable "random" number from a string
+  let hash = 2166136261
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+
+  return Math.abs(hash) % modulo
+}


### PR DESCRIPTION
## Beskrivelse
Fra Marlin fikk jeg definert en god del forskjellige farger på QR-stemplene. Men siden disse bare loopet på index, var det i praksis flere av fargene som aldri ble brukt. Derfor velger jeg nå tilfeldige farger basert på hashen til IDen til posten. Da får man en god distribusjon av forskjellige julefarger 🎄

#️⃣ Punktliste av hva som er endret:

- Legger til en heftig `stableRandomIndex`
- Bruker dette til å hente tilfeldige farger på QR-kodene.


## Bilder

**Før:**
<img width="1184" height="1355" alt="bilde" src="https://github.com/user-attachments/assets/370f393c-25fb-48ef-a93d-108d15f709ae" />


**Etter:**
<img width="993" height="1355" alt="bilde" src="https://github.com/user-attachments/assets/69d50726-fa66-4e5c-a650-2643814a9f3f" />

